### PR TITLE
Refactor Client Data Handling and Implement Channel Join Logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NAME = ircserv
 # Source files
 # For Block 1, we have these:
 # SRCS = main.cpp src/Server.cpp src/Socket.cpp src/Client.cpp
-SRCS = Server.cpp Socket.cpp Client.cpp
+SRCS = Server.cpp Socket.cpp Client.cpp Channel.cpp
 SRCS := main.cpp $(addprefix $(SRCS_DIR)/, $(SRCS))
 
 # Object files (derived from SRCS)

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -2,23 +2,33 @@
 # define CHANNEL_HPP
 
 # include "Socket.hpp"   // Include our Socket class
+# include <set>          // For storing unique client file descriptors
 # include <string>       // For password
 # include <vector>       // For pollfd vector
 # include <iostream>     // For logging
+# include <unordered_map> // For unordered_map
 # include "Client.hpp"
+#include "../includes/Colors.hpp"
 
 class Channel 
 {
 	private:
 		std::string _name;
-		std::vector<Client> _clients;
+		std::set<int> _clients; // Set of unique client file descriptors, that are part of this channel. With this we can access a client directly through the reference to the clients map in Server
+		std::unordered_map<int, Client>& _clients_ref; // Reference to the clients map in Server
 
 	public:
-		Channel(const std::string& name);
+		Channel(const std::string& name, std::unordered_map<int, Client>& clients);
+		Channel(const Channel&) = delete;
+		Channel& operator=(const Channel&) = delete;
+
+		Channel(Channel&& other);
 		~Channel() = default;
-		void add_client(const Client& client);
-		void remove_client(const Client& client);
-		void broadcast_message(const std::string& message, const Client& sender);
+
+		std::set<int> get_clients() const;
+		void add_client(int client_fd);
+		void remove_client(int client_fd);
+		void broadcast_message(const std::string& message, int sender_fd) const;
 };
 
 #endif

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -20,8 +20,10 @@ class Client
 {
 private:
     std::unique_ptr<Socket> _socket;
-    std::string read_buffer = "";
-    std::string write_buffer = "";
+	std::string input_buffer = ""; // When the server sends data to the client, it is stored here
+    std::string output_buffer = ""; // When the client sends data to the server, it is stored here
+
+	// Authentication data
 	std::string _nickname = ""; // from NICK
 	std::string _username = ""; // from USER
 	std::string _realname = "";  // from USER after ':'
@@ -45,15 +47,13 @@ public:
     ~Client() = default;
 
     int get_fd() const;
-
-    void read_data();
-    void write_data();
     void close();
 	bool get_passed_pass() const;
 	bool get_passed_nick() const;
 	bool get_passed_user() const;
 	bool get_passed_realname() const;
 
+	std::string const &get_nickname() const;
 	void set_passed_pass(std::string const &pass);
 	void set_passed_nick(std::string const &nick);
 	void set_passed_user(std::string const &user);
@@ -62,7 +62,12 @@ public:
 	bool is_authenticated() const;
 	void set_authenticated();
 
-	std::string const &get_nickname() const;
+	// std::string const &get_read_buffer() const;
+	// std::string const &get_write_buffer() const;
+
+	void send(std::string const &msg); // Append data to the input_buffer to send to the client
+	void write_output_buffer(std::string const &data); // Append data to the output_buffer to send to the server
+	std::string extract_output_line();
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -13,6 +13,11 @@
 # include <unordered_map> // For mapping client file descriptors to Client objects
 # include "Client.hpp"
 # include "Channel.hpp"
+#include "../includes/Server.hpp"
+#include "../includes/Colors.hpp"
+#include <stdexcept>
+#include <cstring> // For strerror
+#include <sstream> // For std::istringstream
 
 // Constants
 # define DEFAULT_PORT 6667 // Default port for IRC servers
@@ -27,7 +32,6 @@ class Server
 		std::string _password;
 		std::vector<pollfd> _pollfds; // List of file descriptors poll() should monitor
         std::unordered_map<int, Client> _clients; // Map of client fds to Client objects. For client data like read/write buffers, status, nickname, ...
-		std::unordered_map<int, std::string> _client_buffers; // Map of client fds to their read/write buffers
 		std::map<std::string, Channel> _channels; // Map of channel names to Channel objects
 		static bool _signal_received; // For signal handling
 
@@ -47,8 +51,8 @@ class Server
         int parse_pass(std::string line, int client_fd);
         int parse_nick(std::string line, int client_fd);
         int parse_user(std::string line, int client_fd);
+		int handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines);
 
-		
 		public:
 		// Socket get_listening_socket() const;
 		// Constructor: Sets up the server with port and password, creates and binds listening socket

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,13 +6,64 @@
 /*   By: tkeil <tkeil@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 17:50:46 by tkeil             #+#    #+#             */
-/*   Updated: 2025/06/24 18:26:19 by tkeil            ###   ########.fr       */
+/*   Updated: 2025/06/27 19:27:25 by tkeil            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "Channel.hpp"
 
-Channel::Channel(const std::string& name) : _name(name)
+Channel::Channel(const std::string& name, std::unordered_map<int, Client>& clients) : _name(name), _clients_ref(clients)
+{	
+}
+
+Channel::Channel(Channel&& other) : _name(std::move(other._name)), _clients(std::move(other._clients)), _clients_ref(other._clients_ref) {}
+
+void Channel::add_client(int client_fd)
 {
-	
+	if (_clients.find(client_fd) == _clients.end())
+	{
+		_clients.insert(client_fd);
+		std::cout << "Client FD " << client_fd << " added to channel " << _name << std::endl;
+	}
+	else
+	{
+		std::cerr << "Client FD " << client_fd << " is already in channel " << _name << std::endl;
+	}
+}
+
+void Channel::remove_client(int client_fd)
+{
+	if (_clients.find(client_fd) != _clients.end())
+	{
+		_clients.erase(client_fd);
+		std::cout << "Client FD " << client_fd << " removed from channel " << _name << std::endl;
+	}
+	else
+	{
+		std::cerr << "Client FD " << client_fd << " not found in channel " << _name << std::endl;
+	}
+}
+
+std::set<int> Channel::get_clients() const
+{
+	return _clients;
+}
+
+void Channel::broadcast_message(const std::string& message, int sender_fd) const
+{
+	for (const auto& member_fd : _clients)
+	{
+		if (member_fd != sender_fd)
+		{
+			try
+			{
+			    _clients_ref.at(member_fd).send(message);
+			}
+			catch (const std::exception& e)
+			{
+			    std::cerr << "Failed to send join message to client: " << e.what() << std::endl;
+				return ;
+			}
+		}
+	}
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -77,3 +77,49 @@ bool Client::get_passed_realname() const
 {
     return passed_realname;
 }
+
+// Send data to the client
+void Client::send(std::string const &msg)
+{
+    ssize_t bytes_sent = ::send(_socket->get_fd(), msg.c_str(), msg.size(), 0);
+    if (bytes_sent == -1)
+    {
+        std::cerr << "send() failed for client FD " << _socket->get_fd() << ": " << std::strerror(errno) << std::endl;
+        throw std::runtime_error("send() failed");
+    }
+    if (static_cast<size_t>(bytes_sent) < msg.size())
+    {
+        std::cerr << "Warning: Partial send() for client FD " << _socket->get_fd() << std::endl;
+        throw std::runtime_error("Partial send(), incomplete message sent");
+    }
+}
+
+// Write data to the output buffer used for sending data to the server
+void Client::write_output_buffer(std::string const &data)
+{
+	output_buffer += data;
+}
+
+// std::string const &Client::get_read_buffer() const
+// {
+// 	return read_buffer;
+// }
+
+// std::string const &Client::get_write_buffer() const
+// {
+// 	return write_buffer;
+// }
+
+// Extract a line from the output buffer
+std::string Client::extract_output_line()
+{
+	size_t pos = output_buffer.find('\n');
+	if (pos == std::string::npos)
+		return "";
+
+	std::string line = output_buffer.substr(0, pos);
+	output_buffer.erase(0, pos + 1);
+	if (!line.empty() && line.back() == '\r')
+		line.pop_back();
+	return line;
+}


### PR DESCRIPTION
- **Encapsulated send logic**
  - The `send()` functionality is now a method of the `Client` class.
  - Sending is wrapped in a `try-catch` block to safely handle exceptions.

- **Refactored `process_client_data()`**
  - Incoming data is now written to the input buffer using `Client` methods.
  - `extract_output_line()` is called as a method to extract complete lines.
  - The function has become cleaner and follows object-oriented design.

- **Implemented JOIN command**
  - Clients can join channels.
  - Channels are created on demand if they do not exist.
  - Each `Channel` maintains:
    - a `std::set` of client file descriptors (FDs) to track membership.
    - a reference to the server’s clients map to access actual `Client` objects.
  - This approach avoids copying `Client` instances (which hold `unique_ptr` sockets) and removes the need for manual deletion.
  - By keeping a reference to the clients map rather than pointers, channels automatically stop seeing removed clients without requiring explicit cleanup.
