### PR TITLE
Handled Client commands and Used map of function pointers for client commands. Fully RFC 2812 compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NAME = ircserv
 # Source files
 # For Block 1, we have these:
 # SRCS = main.cpp src/Server.cpp src/Socket.cpp src/Client.cpp
-SRCS = Server.cpp Socket.cpp Client.cpp Channel.cpp
+SRCS = Server.cpp Socket.cpp Client.cpp Channel.cpp ParsedMessage.cpp
 SRCS := main.cpp $(addprefix $(SRCS_DIR)/, $(SRCS))
 
 # Object files (derived from SRCS)

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -10,6 +10,8 @@
 # include "Client.hpp"
 #include "../includes/Colors.hpp"
 
+class Server;
+
 class Channel 
 {
 	private:
@@ -29,6 +31,12 @@ class Channel
 		std::set<int> get_members() const;
 		void add_client(int client_fd);
 		size_t remove_client(int client_fd);
+
+		void add_operator(int client_fd);
+		size_t remove_operator(int client_fd);
+
+		bool has_member(int client_fd) const;
+
 		void broadcast_message(const std::string& message, int sender_fd) const;
 };
 

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -14,7 +14,8 @@ class Channel
 {
 	private:
 		std::string _name;
-		std::set<int> _clients; // Set of unique client file descriptors, that are part of this channel. With this we can access a client directly through the reference to the clients map in Server
+		std::set<int> _members; // Set of unique client file descriptors, that are part of this channel. With this we can access a client directly through the reference to the clients map in Server
+		std::set<int> _operators; // Set of operators that can perform special actions like kicking clients, inviting clients, change the channel topic, change the channel mode
 		std::unordered_map<int, Client>& _clients_ref; // Reference to the clients map in Server
 
 	public:
@@ -25,7 +26,7 @@ class Channel
 		Channel(Channel&& other);
 		~Channel() = default;
 
-		std::set<int> get_clients() const;
+		std::set<int> get_members() const;
 		void add_client(int client_fd);
 		size_t remove_client(int client_fd);
 		void broadcast_message(const std::string& message, int sender_fd) const;

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -27,7 +27,7 @@ class Channel
 
 		std::set<int> get_clients() const;
 		void add_client(int client_fd);
-		void remove_client(int client_fd);
+		size_t remove_client(int client_fd);
 		void broadcast_message(const std::string& message, int sender_fd) const;
 };
 

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -53,7 +53,7 @@ public:
 	bool get_passed_user() const;
 	bool get_passed_realname() const;
 
-	std::string const &get_nickname() const;
+	std::string const get_nickname() const;
 	void set_passed_pass(std::string const &pass);
 	void set_passed_nick(std::string const &nick);
 	void set_passed_user(std::string const &user);

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -65,7 +65,7 @@ public:
 	// std::string const &get_read_buffer() const;
 	// std::string const &get_write_buffer() const;
 
-	void send(std::string const &msg); // Append data to the input_buffer to send to the client
+	void send(std::string &msg); // Append data to the input_buffer to send to the client
 	void write_output_buffer(std::string const &data); // Append data to the output_buffer to send to the server
 	std::string extract_output_line();
 };

--- a/includes/ParsedMessage.hpp
+++ b/includes/ParsedMessage.hpp
@@ -1,0 +1,19 @@
+#ifndef PARSED_MESSAGE_HPP
+# define PARSED_MESSAGE_HPP
+
+# include <string>
+# include <vector>
+# include <iostream>
+# include <sstream>
+
+struct ParsedMessage
+{
+	std::string prefix;
+	std::string command;
+	std::vector<std::string> params;
+	ParsedMessage();
+	ParsedMessage(const std::string& line);
+	ParsedMessage(const std::string& p, const std::string& c, const std::vector<std::string>& ps);
+};
+
+# endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -52,6 +52,11 @@ class Server
         int parse_nick(std::string line, int client_fd);
         int parse_user(std::string line, int client_fd);
 		int handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines);
+		int handle_privmsg(int client_fd, std::string &target, std::string const &message);
+		int handle_part(int client_fd, std::string &channel_name);
+		int handle_join(int client_fd, std::string &channel_name);
+		int handle_help(int client_fd);
+		int handle_channels(int client_fd);
 
 		public:
 		// Socket get_listening_socket() const;

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -34,6 +34,8 @@ class Server
         std::unordered_map<int, Client> _clients; // Map of client fds to Client objects. For client data like read/write buffers, status, nickname, ...
 		std::map<std::string, Channel> _channels; // Map of channel names to Channel objects
 		static bool _signal_received; // For signal handling
+		typedef std::function<int(Server&, int, std::istringstream&)> CommandHandler;
+		static const std::unordered_map<std::string, CommandHandler> handlers;
 
 		// Helper methods for socket setup (optional, can be in constructor)
 		bool valid_inputs(int port, const std::string& password);
@@ -44,19 +46,21 @@ class Server
 		void setup_listening_socket();
 		void bind_listening_socket();
 		void listen_on_socket();
-		void handle_authentication(size_t &index, int client_fd, const std::vector<std::string>& lines);
+		// void handle_authentication(size_t &index, int client_fd, const std::vector<std::string>& lines);
 		void process_client_data(size_t& index, int client_fd);
 		bool is_duplicate_nickname(const std::string& nickname);
         // Helper methods for authentication
-        int parse_pass(std::string line, int client_fd);
-        int parse_nick(std::string line, int client_fd);
-        int parse_user(std::string line, int client_fd);
 		int handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines);
-		int handle_privmsg(int client_fd, std::string &target, std::string const &message);
-		int handle_part(int client_fd, std::string &channel_name);
-		int handle_join(int client_fd, std::string &channel_name);
-		int handle_help(int client_fd);
-		int handle_channels(int client_fd);
+		int parse_pass(int fd, std::istringstream& ss);
+        int parse_nick(int fd, std::istringstream& ss);
+        int parse_user(int fd, std::istringstream& ss);
+
+		int handle_privmsg(int fd, std::istringstream& ss);
+		int handle_part(int fd, std::istringstream& ss);
+		int handle_join(int fd, std::istringstream& ss);
+		int handle_help(int fd, std::istringstream& ss);
+		int handle_channels(int fd, std::istringstream& ss);
+		int handle_quit(int fd, std::istringstream& ss);
 
 		public:
 		// Socket get_listening_socket() const;

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -18,6 +18,7 @@
 #include <stdexcept>
 #include <cstring> // For strerror
 #include <sstream> // For std::istringstream
+# include "ParsedMessage.hpp"
 
 // Constants
 # define DEFAULT_PORT 6667 // Default port for IRC servers
@@ -28,13 +29,14 @@ class Server
 {
 	private:
 		Socket _listening_socket; // The socket that accepts new connections
+		std::string _hostname;
 		int _port;
 		std::string _password;
 		std::vector<pollfd> _pollfds; // List of file descriptors poll() should monitor
         std::unordered_map<int, Client> _clients; // Map of client fds to Client objects. For client data like read/write buffers, status, nickname, ...
 		std::map<std::string, Channel> _channels; // Map of channel names to Channel objects
 		static bool _signal_received; // For signal handling
-		typedef std::function<int(Server&, int, std::istringstream&)> CommandHandler;
+		typedef std::function<int(Server&, int, const ParsedMessage&)> CommandHandler;
 		static const std::unordered_map<std::string, CommandHandler> handlers;
 
 		// Helper methods for socket setup (optional, can be in constructor)
@@ -49,20 +51,23 @@ class Server
 		// void handle_authentication(size_t &index, int client_fd, const std::vector<std::string>& lines);
 		void process_client_data(size_t& index, int client_fd);
 		bool is_duplicate_nickname(const std::string& nickname);
+		void broadcast_to_all(const std::string& message, int sender_fd);
+		int find_fd_by_nickname(std::string const &nickname) const;
+
         // Helper methods for authentication
-		int handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines);
-		int parse_pass(int fd, std::istringstream& ss);
-        int parse_nick(int fd, std::istringstream& ss);
-        int parse_user(int fd, std::istringstream& ss);
+		int handle_client_command(size_t &index, int client_fd, const ParsedMessage& parsedmsg);
+		int parse_pass(int fd, const ParsedMessage& msg);
+        int parse_nick(int fd, const ParsedMessage& msg);
+        int parse_user(int fd, const ParsedMessage& msg);
 
-		int handle_privmsg(int fd, std::istringstream& ss);
-		int handle_part(int fd, std::istringstream& ss);
-		int handle_join(int fd, std::istringstream& ss);
-		int handle_help(int fd, std::istringstream& ss);
-		int handle_channels(int fd, std::istringstream& ss);
-		int handle_quit(int fd, std::istringstream& ss);
-
-		public:
+		int handle_privmsg(int fd, const ParsedMessage& msg);
+		int handle_part(int fd, const ParsedMessage& msg);
+		int handle_join(int fd, const ParsedMessage& msg);
+		int handle_help(int fd, const ParsedMessage& msg);
+		int handle_channels(int fd, const ParsedMessage& msg);
+		int handle_quit(int fd, const ParsedMessage& msg);
+		
+	public:
 		// Socket get_listening_socket() const;
 		// Constructor: Sets up the server with port and password, creates and binds listening socket
 		Server(int port, const std::string& password);
@@ -73,6 +78,8 @@ class Server
 		// signal handling methods
 		static void handle_signal(int signum);
 		static void setup_signal_handlers();
+
+		void send_reply(int fd, int code, const std::vector<std::string>& params, const std::string& msg);
 		
 		// void handle_new_connection();
 		// void handle_client_data(int client_fd);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: tkeil <tkeil@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 17:50:46 by tkeil             #+#    #+#             */
-/*   Updated: 2025/06/30 20:33:45 by tkeil            ###   ########.fr       */
+/*   Updated: 2025/07/02 16:47:37 by tkeil            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,9 @@ void Channel::broadcast_message(const std::string& message, int sender_fd) const
 		{
 			try
 			{
-			    _clients_ref.at(member_fd).send("#" + _name + " :" + message);
+				// [#channel1] <bob>: hi everyone => bob from channel1 sends a message to the channel
+				std::string msg = "[#" + _name + "] <" + _clients_ref.at(sender_fd).get_nickname() + ">: " + message;
+			    _clients_ref.at(member_fd).send(msg);
 			}
 			catch (const std::exception& e)
 			{

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,23 +6,23 @@
 /*   By: tkeil <tkeil@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 17:50:46 by tkeil             #+#    #+#             */
-/*   Updated: 2025/07/02 16:47:37 by tkeil            ###   ########.fr       */
+/*   Updated: 2025/07/02 18:53:36 by tkeil            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "Channel.hpp"
 
-Channel::Channel(const std::string& name, std::unordered_map<int, Client>& clients) : _name(name), _clients_ref(clients)
+Channel::Channel(const std::string& name, std::unordered_map<int, Client>& clients) : _name(name), _members(), _clients_ref(clients)
 {	
 }
 
-Channel::Channel(Channel&& other) : _name(std::move(other._name)), _clients(std::move(other._clients)), _clients_ref(other._clients_ref) {}
+Channel::Channel(Channel&& other) : _name(std::move(other._name)), _members(std::move(other._members)), _clients_ref(other._clients_ref) {}
 
 void Channel::add_client(int client_fd)
 {
-	if (_clients.find(client_fd) == _clients.end())
+	if (_members.find(client_fd) == _members.end())
 	{
-		_clients.insert(client_fd);
+		_members.insert(client_fd);
 		std::cout << "Client FD " << client_fd << " added to channel " << _name << std::endl;
 	}
 	else
@@ -33,9 +33,9 @@ void Channel::add_client(int client_fd)
 
 size_t Channel::remove_client(int client_fd)
 {
-	if (_clients.find(client_fd) != _clients.end())
+	if (_members.find(client_fd) != _members.end())
 	{
-		if (!_clients.erase(client_fd))
+		if (!_members.erase(client_fd))
 			return (0);
 		std::cout << "Client FD " << client_fd << " removed from channel " << _name << std::endl;
 	}
@@ -47,14 +47,14 @@ size_t Channel::remove_client(int client_fd)
 	return (1);
 }
 
-std::set<int> Channel::get_clients() const
+std::set<int> Channel::get_members() const
 {
-	return _clients;
+	return _members;
 }
 
 void Channel::broadcast_message(const std::string& message, int sender_fd) const
 {
-	for (const auto& member_fd : _clients)
+	for (const auto& member_fd : _members)
 	{
 		if (member_fd != sender_fd)
 		{

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: tkeil <tkeil@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/24 17:50:46 by tkeil             #+#    #+#             */
-/*   Updated: 2025/06/27 19:27:25 by tkeil            ###   ########.fr       */
+/*   Updated: 2025/06/30 20:33:45 by tkeil            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,17 +31,20 @@ void Channel::add_client(int client_fd)
 	}
 }
 
-void Channel::remove_client(int client_fd)
+size_t Channel::remove_client(int client_fd)
 {
 	if (_clients.find(client_fd) != _clients.end())
 	{
-		_clients.erase(client_fd);
+		if (!_clients.erase(client_fd))
+			return (0);
 		std::cout << "Client FD " << client_fd << " removed from channel " << _name << std::endl;
 	}
 	else
 	{
 		std::cerr << "Client FD " << client_fd << " not found in channel " << _name << std::endl;
+		return (0);
 	}
+	return (1);
 }
 
 std::set<int> Channel::get_clients() const
@@ -57,11 +60,11 @@ void Channel::broadcast_message(const std::string& message, int sender_fd) const
 		{
 			try
 			{
-			    _clients_ref.at(member_fd).send(message);
+			    _clients_ref.at(member_fd).send("#" + _name + " :" + message);
 			}
 			catch (const std::exception& e)
 			{
-			    std::cerr << "Failed to send join message to client: " << e.what() << std::endl;
+			    std::cerr << "Failed to broadcast a message to client: " << e.what() << std::endl;
 				return ;
 			}
 		}

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -27,9 +27,9 @@ bool Client::is_authenticated() const
 	return authenticated;
 }
 
-std::string const &Client::get_nickname() const
+std::string const Client::get_nickname() const
 {
-	return _nickname;
+	return _nickname.empty() ? "anonymous" : _nickname;
 }
 
 void Client::set_passed_pass(std::string const &pass)
@@ -81,7 +81,6 @@ bool Client::get_passed_realname() const
 // Send data to the client
 void Client::send(std::string &msg)
 {
-	msg += "\r\n"; // Ensure the message ends with CRLF
     ssize_t bytes_sent = ::send(_socket->get_fd(), msg.c_str(), msg.size(), 0);
     if (bytes_sent == -1)
     {
@@ -122,5 +121,5 @@ std::string Client::extract_output_line()
 	output_buffer.erase(0, pos + 1);
 	if (!line.empty() && line.back() == '\r')
 		line.pop_back();
-	return line;
+	return (line + "\r\n"); // Return the line with CRLF
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -79,8 +79,9 @@ bool Client::get_passed_realname() const
 }
 
 // Send data to the client
-void Client::send(std::string const &msg)
+void Client::send(std::string &msg)
 {
+	msg += "\r\n"; // Ensure the message ends with CRLF
     ssize_t bytes_sent = ::send(_socket->get_fd(), msg.c_str(), msg.size(), 0);
     if (bytes_sent == -1)
     {

--- a/src/ParsedMessage.cpp
+++ b/src/ParsedMessage.cpp
@@ -1,0 +1,45 @@
+#include "ParsedMessage.hpp"
+
+
+ParsedMessage::ParsedMessage() : prefix(""), command(""), params() {}
+
+ParsedMessage::ParsedMessage(const std::string& line)
+{
+	// Example line:
+	// :alice!~user@localhost PRIVMSG #42 :Hello everyone, welcome to the channel!\r\n
+	// {prefix}: ":alice!~user@localhost"
+	// {command}: "PRIVMSG"
+	// {Params}: {"#42", "Hello everyone, welcome to the channel!"}
+
+	std::string token;
+	std::istringstream ss(line);
+
+	// Getting the prefix
+	if (!token.empty() && token[0] == ':')
+	{
+		ss >> token;
+		prefix = token.substr(1);
+	}
+
+	// Getting the command
+	ss >> command;
+
+	// Getting the parameters
+	bool trailing = false;
+	while (ss >> token)
+	{
+		if (token[0] == ':' && !trailing) {
+			trailing = true;
+			std::string rest;
+			std::getline(ss, rest);
+			params.push_back(token.substr(1) + rest);
+			break;
+		}
+		else
+		{
+			params.push_back(token);
+		}
+	}
+}
+
+ParsedMessage::ParsedMessage(const std::string& p, const std::string& c, const std::vector<std::string>& ps) : prefix(p), command(c), params(ps) {}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,35 +1,39 @@
 #include "../includes/Server.hpp"
+#include "ParsedMessage.hpp"
 
 bool Server::_signal_received = false;
 
 const std::unordered_map<std::string, Server::CommandHandler> Server::handlers = {
-	{"PASS", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.parse_pass(fd, ss);
+	{"PASS", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.parse_pass(fd, msg);
     }},
-	{"NICK", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.parse_nick(fd, ss);
+	{"NICK", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.parse_nick(fd, msg);
     }},
-	{"USER", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.parse_user(fd, ss);
+	{"USER", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.parse_user(fd, msg);
     }},
-    {"PRIVMSG", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_privmsg(fd, ss);
+    {"PRIVMSG", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_privmsg(fd, msg);
     }},
-	{"PART", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_part(fd, ss);
+	{"PART", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_part(fd, msg);
     }},
-	{"JOIN", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_join(fd, ss);
+	{"JOIN", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_join(fd, msg);
     }},
-	{"HELP", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_help(fd, ss);
+	{"HELP", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_help(fd, msg);
     }},
-	{"CHANNELS", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_channels(fd, ss);
+	{"CHANNELS", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_channels(fd, msg);
     }},
-	{"QUIT", [](Server& srv, int fd, std::istringstream& ss) {
-        return srv.handle_quit(fd, ss);
+	{"QUIT", [](Server& srv, int fd, const ParsedMessage& msg) {
+        return srv.handle_quit(fd, msg);
     }},
+	// {"MODE", [](Server& srv, int fd, const ParsedMessage& msg) {
+    //     return srv.handle_mode(fd, msg);
+    // }},
 };
 
 // Helper functions
@@ -89,9 +93,16 @@ sockaddr_in Server::create_sockaddr_in(int port)
 // Constructor: Sets up the server
 Server::Server(int port, const std::string& password)
 	: _listening_socket(), // Initialize the listening socket (calls Socket::Socket())
+	_hostname(""),
 	_port(port),
 	_password(password)
 {
+	char hostname_buffer[256];
+	if (gethostname(hostname_buffer, sizeof(hostname_buffer)) != 0)
+	{
+		throw std::runtime_error(std::string("Failed to get hostname: ") + std::strerror(errno));
+	}
+	_hostname = hostname_buffer;
 	if (!valid_inputs(port, password))
 		return;
 	// Setup the server address structure
@@ -203,13 +214,11 @@ void Server::handle_new_connection()
 	// Initialize revents to 0
 	_pollfds.push_back({client_fd, POLLIN, 0});
 	try
-	{
-		std::string welcome_message = std::string(GREEN) + "Welcome to the server! You are connected with FD " + std::to_string(client_fd) + ".\n" + RESET
-									  "Please authenticate using the following commands:\n" + std::string(BLUE) + std::string(BOLD) + 
-									  "PASS <password>\n" +
-									  "NICK <nickname>\n" +
-									  "USER <username> 0 * :realname" + RESET;
-		_clients.at(client_fd).send(welcome_message);
+	{	
+		send_reply(client_fd, 704, { _clients.at(client_fd).get_nickname(), "*" }, "*** Available Commands ***");
+		send_reply(client_fd, 705, { _clients.at(client_fd).get_nickname(), "*" }, "PASS <password>");
+		send_reply(client_fd, 705, { _clients.at(client_fd).get_nickname(), "*" }, "NICK <nickname>");
+		send_reply(client_fd, 705, { _clients.at(client_fd).get_nickname(), "*" }, "USER <username> 0 * :realname\n");
 	}
 	catch (const std::exception& e)
 	{
@@ -235,456 +244,471 @@ void Server::handle_disconnection(size_t& index)
 	std::cout << GREEN << "Client removed from poll list." << RESET << std::endl;
 }
 
-int Server::parse_pass(int fd, std::istringstream& ss)
+void Server::send_reply(int fd, int code, const std::vector<std::string>& params, const std::string& msg)
 {
-	std::string pass;
-	std::getline(ss >> std::ws, pass);
-    if (!_clients.at(fd).get_passed_pass())
-    {
-        if (pass == _password)
-        {
-            _clients.at(fd).set_passed_pass(pass);
-        }
-        else
-        {
-            std::cerr << RED << "Client FD " << fd << " failed authentication with PASS command.\n" << RESET;
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: Invalid password" + RESET;
-				_clients.at(fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-            return -1;
-        }
+	std::string text = ':' + _hostname + ' ' + std::to_string(code) + ' ';
+    for (size_t i = 0; i < params.size(); ++i)
+	{
+        if (i)
+			text += ' ';
+		text += params[i];
     }
-    else
-    {
-        std::cerr << RED << "Client FD " << fd << ". You may not reregister" << RESET;
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You may not reregister" + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-        return -1;
-    }
-    return (0);
+    text += " :" + msg + "\r\n";
+	_clients.at(fd).send(text);
 }
 
-int Server::parse_nick(int fd, std::istringstream& ss)
+int Server::parse_pass(int fd, const ParsedMessage& msg)
 {
-	std::string nick;
-	std::getline(ss >> std::ws, nick);
-    if (is_duplicate_nickname(nick)
-		|| nick.find_first_of(" \n\r\v\t\f") != std::string::npos
-		|| !std::all_of(nick.begin(), nick.end(), [](unsigned char c){ return std::isalnum(c); }))
-    {
+	std::cout << "Parsing PASS command for FD " << fd << std::endl;
+	std::cout << "Client FD " << fd << " sent PASS command with params: ";
+	for (const auto& param : msg.params)
+	{
+		std::cout << param << " ";
+	}
+	std::cout << std::endl;
+
+	Client& client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (client.get_passed_pass())
+	{
 		try
 		{
-			std::string msg = std::string(RED) + "ERROR: Invalid nickname or a duplicate. Try it with another nickname" + RESET;
-			_clients.at(fd).send(msg);
+			send_reply(fd, 462, { nickname, "PASS" }, "You may not reregister");
 		}
 		catch (const std::exception& e)
 		{
 			std::cerr << "Error sending message: " << e.what() << std::endl;
 		}
-		return 1;
+		return 0;
+	}
+
+	if (msg.params.size() != 1 || msg.params[0].empty())
+	{
+		try
+		{
+			send_reply(fd, 461, { nickname, "PASS" }, "Not enough parameters");
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 0;
+	}
+
+	if (msg.params[0] != this->_password)
+	{
+		try
+		{
+			send_reply(fd, 464, { nickname, "PASS" }, "Password incorrect");
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 0;
+	}
+
+	client.set_passed_pass(msg.params[0]);
+	return 0;
+}
+
+int Server::parse_nick(int fd, const ParsedMessage& msg)
+{
+	std::cout << "Parsing NICK command for FD " << fd << std::endl;
+	std::cout << "Client FD " << fd << " sent NICK command with params: ";
+	for (const auto& param : msg.params)
+	{
+		std::cout << param << " ";
+	}
+	std::cout << std::endl;
+
+	Client& client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (msg.params.empty() || msg.params[0].empty())
+    {
+		try
+		{
+			send_reply(fd, 431, { nickname, "NICK" }, "No nickname given");
+		}
+		catch(const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+        return 0;
     }
-    _clients.at(fd).set_passed_nick(nick);
+	std::string nick = msg.params[0];
+    if (!nick.empty() && nick[0] == ':')
+        nick.erase(0, 1);
+
+	if (![](const std::string &s)
+		{ return !s.empty() &&
+				 std::all_of(s.begin(), s.end(),
+							 [](unsigned char c)
+							 { return std::isalnum(c); }); })
+	{
+		try
+		{
+			send_reply(fd, 432, { nickname, "NICK" }, "Erroneous nickname");
+		}
+		catch (const std::exception &e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 0;
+	}
+
+	if (is_duplicate_nickname(nick))
+    {
+		try
+		{
+			send_reply(fd, 433, { nickname, "NICK" }, "Nickname is already in use");
+		}
+		catch(const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+        return 0;
+    }
+	std::string old = client.get_nickname();
+    client.set_passed_nick(nick);
+	if (!old.empty() && old != "anonymous" && old != nick)
+    {
+        std::string text = old + " is now known as " + nick;
+		broadcast_to_all(text, fd);
+    }
     std::cout << GREEN << "Client FD " << fd << " set nickname to " << nick << ".\n" << RESET;
     return (0);
 }
 
-int Server::parse_user(int fd, std::istringstream& ss)
+void Server::broadcast_to_all(const std::string& message, int sender_fd)
 {
-    if (!_clients.at(fd).get_passed_user())
-    {
-        std::string username, hostname, servername, real;
-        ss >> username >> hostname >> servername;
-        std::getline(ss >> std::ws, real);
-        if (real.empty()
-			|| real[0] != ':'
-			|| hostname != "0"
-			|| servername != "*"
-			|| username.empty()
-			|| username.find_first_of(" \n\r\v\t\f") != std::string::npos
-			|| !std::all_of(username.begin(), username.end(), [](unsigned char c){ return std::isalnum(c); }))
-        {
+	for (const auto& client : _clients)
+	{
+		if (client.first != sender_fd)
+		{
+			std::string nickname = client.second.get_nickname();
 			try
 			{
-				std::string msg = std::string(RED) + "ERROR: Invalid USER command format. Use: USER <username> 0 * :realname" + RESET;
-				_clients.at(fd).send(msg);
+				send_reply(client.first, 462, { nickname }, message);
 			}
 			catch (const std::exception& e)
 			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}       
-            return 1;
-        }
-        _clients.at(fd).set_passed_user(username);
-        _clients.at(fd).set_passed_realname(real.substr(1));
-        std::cout << GREEN << "Client FD " << fd << " set user to " << username << " with real name: " << real.substr(1) << ".\n" << RESET;
-    }
-    else
-    {
-        std::cerr << RED << "Client FD " << fd << ". You may not reregister.\n" << RESET;
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You may not reregister" + RESET;
-			_clients.at(fd).send(msg);
+				std::cerr << "Error sending message: " << e.what() << '\n';
+			}
 		}
+	}
+}
+
+int Server::parse_user(int fd, const ParsedMessage& msg)
+{
+	std::cout << "Parsing USER command for FD " << fd << std::endl;
+	std::cout << "Client FD " << fd << " sent USER command with params: ";
+	for (const auto& param : msg.params)
+	{
+		std::cout << param << " ";
+	}
+	std::cout << std::endl;
+
+	Client& client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+	if (client.get_passed_user())
+    {
+        try
+		{
+            send_reply(fd, 462, { nickname, "USER" }, "You may not reregister");
+        }
 		catch (const std::exception& e)
 		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-			return 1;
-		}        
+            std::cerr << "Error sending message: " << e.what() << '\n';
+        }
+        return 0;
     }
+    if (msg.params.size() < 4)
+    {
+        try
+		{
+            send_reply(fd, 461, { nickname, "USER" }, "Not enough parameters");
+        }
+		catch (const std::exception& e)
+		{
+            std::cerr << "Error sending message: " << e.what() << '\n';
+        }
+        return 0;
+    }
+	const std::string& username = msg.params[0];
+    const std::string& hostname = msg.params[1];
+    const std::string& servername = msg.params[2];
+    std::string  realname = msg.params[3];
+	if (!realname.empty() && realname[0] == ':')
+		realname.erase(0, 1);
+
+	if (username.empty() ||
+		hostname != "0" ||
+		servername != "*" ||
+		username.find_first_of(" \t\r\n\v\f") != std::string::npos ||
+		!std::all_of(username.begin(), username.end(),
+					 [](unsigned char c)
+					 { return std::isalnum(c); }))
+	{
+		try
+		{
+			send_reply(fd, 461, { nickname, "USER" }, "Invalid USER format. Use: USER <username> 0 * :realname");
+		}
+		catch (const std::exception &e)
+		{
+			std::cerr << "Error sending message: " << e.what() << '\n';
+		}
+		return 0;
+	}
+
+	client.set_passed_user(username);
+    client.set_passed_realname(realname);
+    std::cout << GREEN << "Client FD " << fd << " set user to " << username << " with real name: " << realname << ".\n" << RESET;
     return (0);
 }
 
-
-int Server::handle_help(int fd, std::istringstream& ss)
+int Server::handle_help(int fd, const ParsedMessage &msg)
 {
-	(void)ss;
-	try
-	{
-		std::string msg = std::string(GREEN) +
-		"Use the following commands:\n" +
-		+ RESET +
-		std::string(BLUE) + std::string(BOLD) + "HELP " + RESET + "(to see this message again)\n" +
-		std::string(BLUE) + std::string(BOLD) + "CHANNELS " + RESET + "(to see which channels you are in)\n" +
-		std::string(BLUE) + std::string(BOLD) + "JOIN <#channel_name> " + RESET + "(to join a channel)\n" +
-		std::string(BLUE) + std::string(BOLD) + "PART <#channel_name> " + RESET + "(to leave a channel)\n" +
-		std::string(BLUE) + std::string(BOLD) + "PRIVMSG <#channel_name or nickname> <message> " + RESET + "(to send a message to a channel)\n" +
-		std::string(BLUE) + std::string(BOLD) + "NICK <nickname> " + RESET + "(to change your nickname)\n" +
-		std::string(BLUE) + std::string(BOLD) + "QUIT " + RESET + "(to disconnect from the server)";
-		_clients.at(fd).send(msg);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return 1;
-	}
+	(void)msg;
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	send_reply(fd, 704, {nickname, "*"}, "*** Available HELP topics ***");
+	send_reply(fd, 705, {nickname, "*"}, "HELP                    :show this list");
+	send_reply(fd, 705, {nickname, "*"}, "CHANNELS                :list channels you are in");
+	send_reply(fd, 705, {nickname, "*"}, "JOIN <#channel>         :join/create channel");
+	send_reply(fd, 705, {nickname, "*"}, "PART <#channel>         :leave channel");
+	send_reply(fd, 705, {nickname, "*"}, "PRIVMSG <target> <text> :send a message");
+	send_reply(fd, 705, {nickname, "*"}, "QUIT                    :disconnect");
+	send_reply(fd, 706, {nickname, "*"}, "*** End of HELP ***\n");
 	return 0;
 }
 
-int Server::handle_channels(int fd, std::istringstream& ss)
+int Server::handle_channels(int fd, const ParsedMessage& msg)
 {
-	// It doenst use the stringstream ss, so it must be used to avoid unused parameter warning
-	(void)ss;
+	(void)msg;
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
 	try
 	{
-		std::string msg = std::string(GREEN) + "You are in the following channels:\n";
+		std::string list;
 		for (const auto& channel : _channels)
 		{
 			if (channel.second.get_members().count(fd))
 			{
-				msg += std::string(BLUE) + std::string(BOLD) + "#" + channel.first + "\n";
+				list + '#' + channel.first + ' ';
 			}
 		}
-		if (msg == std::string(GREEN) + "You are in the following channels:\n")
-			msg += "None\n";
-		msg += RESET;
-		_clients.at(fd).send(msg);
+		if (list.empty())
+		{
+			list = "None";
+		}
+		send_reply(fd, 705, { nickname, "CHANNELS" }, list);
+
 	}
 	catch (const std::exception& e)
 	{
 		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return 1;
+		return 0;
 	}
 	return 0;
 }
 
-int Server::handle_join(int fd, std::istringstream& ss)
+int Server::handle_join(int fd, const ParsedMessage& msg)
 {
-	std::string channel_name;
-	std::getline(ss >> std::ws, channel_name);
-	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (msg.params.empty())
 	{
-		std::cerr << RED << "Client FD " << fd << " sent an invalid JOIN command: " << channel_name << RESET << std::endl;
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return 1;
+		send_reply(fd, 461, { nickname, "JOIN" }, "Not enough parameters");
+		return 0;
 	}
-	channel_name.erase(0, 1);
-	// Check if the channel already exists
-	auto it = _channels.find(channel_name);
-	if (it == _channels.end())
+
+	std::string chan = msg.params[0];
+    if (chan.empty() || chan[0] != '#')
 	{
-		// Channel doesnt exist => create it
-		_channels.emplace(channel_name, Channel(channel_name, _clients));
-		std::cout << GREEN << "Channel " << channel_name << " was created!" << RESET << std::endl;
+		send_reply(fd, 476, { nickname, "JOIN" }, "Bad channel name");
+		return 0;
 	}
+
+	chan.erase(0, 1);
+
+	// Add the channel to the channels map, if it doesn't exist
+	if (!_channels.count(chan))
+		_channels.emplace(chan, Channel(chan, _clients));
+
 	// Add the client to the channel
-	_channels.at(channel_name).add_client(fd);
+	_channels.at(chan).add_client(fd);
 	try
 	{
-		std::string msg = std::string(GREEN) + "You have joined channel: " + channel_name + RESET;
-		_clients.at(fd).send(msg);
+		send_reply(fd, 476, { nickname }, "You have joined the channel " + chan);
 	}
 	catch (const std::exception& e)
 	{
 		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return 1;
+		return 0;
 	}
-	std::string message = "Joined the channel";
-	std::cout << GREEN << message << RESET << std::endl;
 	// Notify other clients in the channel (forward a message to all other clients in the channel)
-	_channels.at(channel_name).broadcast_message(message, fd);
+	_channels.at(chan).broadcast_message(client.get_nickname() + " has joined the channel", fd);
 	return 0;
 }
 
-int Server::handle_part(int fd, std::istringstream& ss)
+int Server::handle_part(int fd, const ParsedMessage& msg)
 {
-	std::string channel_name;
-	std::getline(ss >> std::ws, channel_name);
-	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+    if (msg.params.empty())
 	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return 1;
+        send_reply(fd, 461, { nickname, "PART" }, "Not enough parameters");
+		return 0;
 	}
-	channel_name.erase(0, 1);
-	auto it = _channels.find(channel_name);
+
+	std::string chan = msg.params[0];
+    if (chan[0] != '#')
+	{
+		send_reply(fd, 476, { nickname, "PART" }, "Bad channel mask");
+		return 0;
+	}
+
+	chan.erase(0,1);
+
+	auto it = _channels.find(chan);
 	if (it == _channels.end())
 	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return 1;
+		send_reply(fd, 403, { nickname, "PART", "#" + chan}, "No such channel");
+		return 0;
 	}
-	if (!_channels.at(channel_name).remove_client(fd))
+
+	if (!it->second.remove_client(fd))
 	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return 1;
+		send_reply(fd, 442, { nickname, "PART", "#" + chan}, "You're not on that channel");
+		return 0;
 	}
-	std::string message = "Has left the channel.";
-	std::cout << GREEN << message << RESET << std::endl;
-	// Notify other clients in the channel (forward a message to all other clients in the channel)
-	_channels.at(channel_name).broadcast_message(message, fd);
-	try
-	{
-		std::string msg = std::string(GREEN) + "You have left the channel: " + channel_name + RESET;
-		_clients.at(fd).send(msg);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return 1;
-	}
+
+	_channels.at(chan).broadcast_message(client.get_nickname() + " has left the channel.", fd);
 	return 0;
 }
 
-int Server::handle_privmsg(int fd, std::istringstream& ss)
+int Server::find_fd_by_nickname(std::string const &nickname) const
 {
-	std::string target, message;
-	std::getline(ss >> std::ws, target, ' ');
-	std::getline(ss >> std::ws, message);
-	if (target.empty() || message.empty())
+	for (const auto& client : _clients)
 	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid PRIVMSG command format. Use PRIVMSG <#channel_name or nickname> <message>" + RESET;
-			_clients.at(fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
+		if (client.second.get_nickname() == nickname)
+			return client.first;
 	}
-	if (target[0] == '#')
-	{
-		// Target is a channel
-		target.erase(0, 1);
-		auto it = _channels.find(target);
-		if (it == _channels.end())
-		{
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: Channel does not exist" + RESET;
-				_clients.at(fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-			return -1;
-		}
-		it->second.broadcast_message(message, fd);
-	}
-	else
-	{
-		// Target is a user
-		bool found = false;
-		for (auto& client : _clients)
-		{
-			if (client.second.get_nickname() == target)
-			{
-				try
-				{
-					std::string msg = "<" + _clients.at(fd).get_nickname() + ": " + message + RESET;
-					client.second.send(msg);
-				}
-				catch (const std::exception& e)
-				{
-					std::cerr << "Error sending message: " << e.what() << std::endl;
-					continue;
-				}
-				found = true;
-				break;
-			}
-		}
-		if (!found)
-		{
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: User does not exist." + RESET;
-				_clients.at(fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-		}
-	}
-	return 0;
-}
-
-int Server::handle_quit(int fd, std::istringstream& ss)
-{
-	(void)ss;
-	(void)fd;
 	return -1;
 }
 
-int Server::handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines)
+int Server::handle_privmsg(int fd, const ParsedMessage& msg)
 {
-    std::cout << "Handling command for client FD " << client_fd << std::endl;
-    for (auto &line : lines)
+	Client& client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+	if (msg.params.size() < 2)
+	{
+		send_reply(fd, 442, { nickname, "PRIVMSG" }, "Not enough parameters");
+		return 0;
+	}
+	const std::string& target = msg.params[0];
+    std::string text = msg.params[1];
+    if (!text.empty() && text[0] == ':')
+        text.erase(0,1);
+
+	if (!target.empty() && target[0] == '#')
+	{
+		std::string chan = target.substr(1);
+        auto it = _channels.find(chan);
+		if (it == _channels.end())
+		{
+			send_reply(fd, 403, { nickname, "PRIVMSG", target }, "Not such channel");
+			return 0;
+		}
+
+		Channel& ch = it->second;
+		if (!ch.has_member(fd))
+		{
+			send_reply(fd, 404, { nickname, "PRIVMSG", target }, "Cannot send to channel");
+			return 0;
+		}
+		
+        ch.broadcast_message(text, fd);
+
+		return 0;
+	}
+
+	int fdtg = find_fd_by_nickname(target);
+	if (fdtg == -1)
+	{
+		send_reply(fd, 401, { nickname, "PRIVMSG", target }, "No such nickname");
+		return 0;
+	}
+
+	std::string message = ':' + _clients.at(fd).get_nickname() + "@host PRIVMSG " + " :" + text + "\r\n";
+	_clients.at(fdtg).send(message);
+	// send_reply(fdtg, 705, { nickname, "PRIVMSG", target }, message);
+	return 0;
+}
+
+int Server::handle_quit(int fd, const ParsedMessage& msg)
+{
+	(void)fd;
+	(void)msg;
+	return -1;
+}
+
+int Server::handle_client_command(size_t &index, int client_fd, const ParsedMessage& parsedmsg)
+{
+	if (parsedmsg.command.empty())
+	{
+		return 0;
+	}
+
+	Client& client = _clients.at(client_fd);
+	std::string nickname = client.get_nickname();
+
+	if (parsedmsg.command != "PASS" && !client.get_passed_pass())
     {
-        std::string command;
-        std::istringstream ss(line);
-        ss >> command;
-		auto it = handlers.find(command);
-		if (command != "PASS" && !_clients.at(client_fd).get_passed_pass())
-		{
-			try
-			{
-				std::string msg = std::string(YELLOW) + "Your're not authenticated yet. Use PASS <password>, NICK <nickname> or USER <username 0 * :real-name>" + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-			continue;
-		}
-		else if (command != "PASS" && command != "NICK" && command != "USER" && !_clients.at(client_fd).is_authenticated())
-		{
-			try
-			{
-				std::string msg = std::string(YELLOW) + "You must authenticate with PASS, NICK, and USER commands before sending other commands." + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-			continue;
-		}
-        if (it != handlers.end())
-        {
-			if (it->second(*this, client_fd, ss) == -1)
-			{
-				handle_disconnection(index);
-				return 1;
-			}
-        }
-        else
-        {
-			if (!_clients.at(client_fd).is_authenticated())
-			{
-				try
-				{
-					std::string msg = std::string(RED) + "ERROR: Invalid command. Use PASS, NICK, or USER." + RESET;
-					_clients.at(client_fd).send(msg);
-				}
-				catch (const std::exception& e)
-				{
-					std::cerr << "Error sending message: " << e.what() << std::endl;
-				}
-				continue;
-			}
-			else
-			{
-				try
-				{
-					std::string msg = std::string(RED) + "ERROR: Invalid command. Use JOIN, PART, PRIVMSG, QUIT, NICK, or USER." + RESET;
-					_clients.at(client_fd).send(msg);
-				}
-				catch (const std::exception& e)
-				{
-					std::cerr << "Error sending message: " << e.what() << std::endl;
-				}
-				continue;
-			}
-        }
+        send_reply(client_fd, 451, { nickname }, "You have not registered");
+        return 0;
     }
-	if (!_clients.at(client_fd).is_authenticated() &&
-    	_clients.at(client_fd).get_passed_pass() &&
-        _clients.at(client_fd).get_passed_nick() &&
-        _clients.at(client_fd).get_passed_user())
+
+	if (!client.is_authenticated() &&
+		parsedmsg.command != "PASS" &&
+		parsedmsg.command != "NICK" &&
+		parsedmsg.command != "USER")
+	{
+		send_reply(client_fd, 451, { nickname }, "You have not registered");
+		return 0;
+	}
+
+	auto it = handlers.find(parsedmsg.command);
+    if (it == handlers.end())
     {
-        _clients.at(client_fd).set_authenticated();
-        std::cout << GREEN << "Client FD " << client_fd << " successfully authenticated." << RESET << std::endl;
-		try
-		{
-			std::string msg = std::string(GREEN) + "Welcome to the server, " + _clients.at(client_fd).get_nickname() + ". You are now authenticated!" + RESET;
-			_clients.at(client_fd).send(msg);
-			std::istringstream params("");
-			handle_help(client_fd, params);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-			return 1;
-		}
+        send_reply(client_fd, 421, { nickname, parsedmsg.command }, "Unknown command");
+        return 0;
     }
+    if (it->second(*this, client_fd, parsedmsg) == -1)
+    {
+        handle_disconnection(index);
+        return 1;
+    }
+
+	if (!client.is_authenticated() &&
+		client.get_passed_pass() &&
+		client.get_passed_nick() &&
+		client.get_passed_user())
+	{
+		client.set_authenticated();
+
+		send_reply(client_fd, 001, { nickname },
+				   "Welcome to ft_irc, " + client.get_nickname());
+
+		handle_help(client_fd, ParsedMessage(""));
+	}
 	return 0;
 }
 
@@ -710,21 +734,14 @@ void Server::process_client_data(size_t& index, int client_fd)
 		return ;
 	}
 	std::string line;
-	std::vector<std::string> lines;
-	while (!(line = _clients.at(client_fd).extract_output_line()).empty())
-	{
-		lines.push_back(line);
-	}
+	line = _clients.at(client_fd).extract_output_line();
+
 	// If there are no complete lines => just return
-	if (lines.empty())
+	if (line.empty())
 		return ;
-	// handle authentication. Check if the client sent PASS, NICK, USER commands. If not, send an error message back.
-	// if (!_clients.at(client_fd).is_authenticated())
-	// {
-	// 	handle_authentication(index, client_fd, lines);
-	// }
-	// // If the client is authenticated, process the command
-	handle_client_command(index, client_fd, lines);
+	
+	ParsedMessage parsedmsg(line);
+	handle_client_command(index, client_fd, parsedmsg);
 }
 
 // The main server loop for Block 1

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -2,6 +2,36 @@
 
 bool Server::_signal_received = false;
 
+const std::unordered_map<std::string, Server::CommandHandler> Server::handlers = {
+	{"PASS", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.parse_pass(fd, ss);
+    }},
+	{"NICK", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.parse_nick(fd, ss);
+    }},
+	{"USER", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.parse_user(fd, ss);
+    }},
+    {"PRIVMSG", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_privmsg(fd, ss);
+    }},
+	{"PART", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_part(fd, ss);
+    }},
+	{"JOIN", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_join(fd, ss);
+    }},
+	{"HELP", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_help(fd, ss);
+    }},
+	{"CHANNELS", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_channels(fd, ss);
+    }},
+	{"QUIT", [](Server& srv, int fd, std::istringstream& ss) {
+        return srv.handle_quit(fd, ss);
+    }},
+};
+
 // Helper functions
 bool Server::is_duplicate_nickname(const std::string& nickname)
 {
@@ -205,21 +235,23 @@ void Server::handle_disconnection(size_t& index)
 	std::cout << GREEN << "Client removed from poll list." << RESET << std::endl;
 }
 
-int Server::parse_pass(std::string pass, int client_fd)
+int Server::parse_pass(int fd, std::istringstream& ss)
 {
-    if (!_clients.at(client_fd).get_passed_pass())
+	std::string pass;
+	std::getline(ss >> std::ws, pass);
+    if (!_clients.at(fd).get_passed_pass())
     {
         if (pass == _password)
         {
-            _clients.at(client_fd).set_passed_pass(pass);
+            _clients.at(fd).set_passed_pass(pass);
         }
         else
         {
-            std::cerr << RED << "Client FD " << client_fd << " failed authentication with PASS command.\n" << RESET;
+            std::cerr << RED << "Client FD " << fd << " failed authentication with PASS command.\n" << RESET;
 			try
 			{
 				std::string msg = std::string(RED) + "ERROR: Invalid password" + RESET;
-				_clients.at(client_fd).send(msg);
+				_clients.at(fd).send(msg);
 			}
 			catch (const std::exception& e)
 			{
@@ -230,11 +262,11 @@ int Server::parse_pass(std::string pass, int client_fd)
     }
     else
     {
-        std::cerr << RED << "Client FD " << client_fd << ". You may not reregister" << RESET;
+        std::cerr << RED << "Client FD " << fd << ". You may not reregister" << RESET;
 		try
 		{
 			std::string msg = std::string(RED) + "ERROR: You may not reregister" + RESET;
-			_clients.at(client_fd).send(msg);
+			_clients.at(fd).send(msg);
 		}
 		catch (const std::exception& e)
 		{
@@ -242,11 +274,13 @@ int Server::parse_pass(std::string pass, int client_fd)
 		}
         return -1;
     }
-    return (1);
+    return (0);
 }
 
-int Server::parse_nick(std::string nick, int client_fd)
+int Server::parse_nick(int fd, std::istringstream& ss)
 {
+	std::string nick;
+	std::getline(ss >> std::ws, nick);
     if (is_duplicate_nickname(nick)
 		|| nick.find_first_of(" \n\r\v\t\f") != std::string::npos
 		|| !std::all_of(nick.begin(), nick.end(), [](unsigned char c){ return std::isalnum(c); }))
@@ -254,27 +288,26 @@ int Server::parse_nick(std::string nick, int client_fd)
 		try
 		{
 			std::string msg = std::string(RED) + "ERROR: Invalid nickname or a duplicate. Try it with another nickname" + RESET;
-			_clients.at(client_fd).send(msg);
+			_clients.at(fd).send(msg);
 		}
 		catch (const std::exception& e)
 		{
 			std::cerr << "Error sending message: " << e.what() << std::endl;
 		}
-		return -1;
+		return 1;
     }
-    _clients.at(client_fd).set_passed_nick(nick);
-    std::cout << GREEN << "Client FD " << client_fd << " set nickname to " << nick << ".\n" << RESET;
-    return (1);
+    _clients.at(fd).set_passed_nick(nick);
+    std::cout << GREEN << "Client FD " << fd << " set nickname to " << nick << ".\n" << RESET;
+    return (0);
 }
 
-int Server::parse_user(std::string user, int client_fd)
+int Server::parse_user(int fd, std::istringstream& ss)
 {
-    if (!_clients.at(client_fd).get_passed_user())
+    if (!_clients.at(fd).get_passed_user())
     {
-        std::istringstream iss(user);
         std::string username, hostname, servername, real;
-        iss >> username >> hostname >> servername;
-        std::getline(iss >> std::ws, real);
+        ss >> username >> hostname >> servername;
+        std::getline(ss >> std::ws, real);
         if (real.empty()
 			|| real[0] != ':'
 			|| hostname != "0"
@@ -286,117 +319,39 @@ int Server::parse_user(std::string user, int client_fd)
 			try
 			{
 				std::string msg = std::string(RED) + "ERROR: Invalid USER command format. Use: USER <username> 0 * :realname" + RESET;
-				_clients.at(client_fd).send(msg);
+				_clients.at(fd).send(msg);
 			}
 			catch (const std::exception& e)
 			{
 				std::cerr << "Error sending message: " << e.what() << std::endl;
 			}       
-            return -1;
+            return 1;
         }
-        _clients.at(client_fd).set_passed_user(username);
-        _clients.at(client_fd).set_passed_realname(real.substr(1));
-        std::cout << GREEN << "Client FD " << client_fd << " set user to " << username << " with real name: " << real.substr(1) << ".\n" << RESET;
+        _clients.at(fd).set_passed_user(username);
+        _clients.at(fd).set_passed_realname(real.substr(1));
+        std::cout << GREEN << "Client FD " << fd << " set user to " << username << " with real name: " << real.substr(1) << ".\n" << RESET;
     }
     else
     {
-        std::cerr << RED << "Client FD " << client_fd << ". You may not reregister.\n" << RESET;
+        std::cerr << RED << "Client FD " << fd << ". You may not reregister.\n" << RESET;
 		try
 		{
 			std::string msg = std::string(RED) + "ERROR: You may not reregister" + RESET;
-			_clients.at(client_fd).send(msg);
+			_clients.at(fd).send(msg);
 		}
 		catch (const std::exception& e)
 		{
 			std::cerr << "Error sending message: " << e.what() << std::endl;
-			return -1;
+			return 1;
 		}        
     }
-    return (1);
+    return (0);
 }
 
-void Server::handle_authentication(size_t &index, int client_fd, const std::vector<std::string> &lines)
-{
-    std::cout << "Handling authentication for client FD " << client_fd << std::endl;
-    for (auto &line : lines)
-    {
-        std::string command;
-        std::istringstream ss(line);
-        ss >> command;
-        if (command == "PASS")
-        {
-            std::string password;
-            std::getline(ss >> std::ws, password);
-            if (parse_pass(password, client_fd) == -1)
-            {
-                handle_disconnection(index);
-                return ;
-            }
-        }
-		else if (command != "PASS" && !_clients.at(client_fd).get_passed_pass())
-		{
-			try
-			{
-				std::string msg = std::string(YELLOW) + "Your're not authenticated yet. Use PASS <password>, NICK <nickname> or USER <username 0 * :real-name>" + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-				continue;
-			}
-		}
-        else if (command == "NICK")
-        {
-            std::string nickname;
-            std::getline(ss >> std::ws, nickname);
-            if (parse_nick(nickname, client_fd) == -1)
-                continue;
-        }
-        else if (command == "USER")
-        {
-            std::string user;
-            std::getline(ss >> std::ws, user);
-            if (parse_user(user, client_fd) == -1)
-                continue;
-        }
-        else
-        {
-            std::cerr << RED << "Client FD " << client_fd << " sent an invalid command: " << command << RESET << std::endl;
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: Invalid command. Use PASS, NICK, or USER." + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-				continue;
-			}
-        }
-    }
-    if (_clients.at(client_fd).get_passed_pass() &&
-        _clients.at(client_fd).get_passed_nick() &&
-        _clients.at(client_fd).get_passed_user())
-    {
-        _clients.at(client_fd).set_authenticated();
-        std::cout << GREEN << "Client FD " << client_fd << " successfully authenticated." << RESET << std::endl;
-		try
-		{
-			std::string msg = std::string(GREEN) + "Welcome to the server, " + _clients.at(client_fd).get_nickname() + ". You are now authenticated!" + RESET;
-			_clients.at(client_fd).send(msg);
-			handle_help(client_fd);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-			return ;
-		}
-    }
-}
 
-int Server::handle_help(int client_fd)
+int Server::handle_help(int fd, std::istringstream& ss)
 {
+	(void)ss;
 	try
 	{
 		std::string msg = std::string(GREEN) +
@@ -409,15 +364,330 @@ int Server::handle_help(int client_fd)
 		std::string(BLUE) + std::string(BOLD) + "PRIVMSG <#channel_name or nickname> <message> " + RESET + "(to send a message to a channel)\n" +
 		std::string(BLUE) + std::string(BOLD) + "NICK <nickname> " + RESET + "(to change your nickname)\n" +
 		std::string(BLUE) + std::string(BOLD) + "QUIT " + RESET + "(to disconnect from the server)";
-		_clients.at(client_fd).send(msg);
+		_clients.at(fd).send(msg);
 	}
 	catch (const std::exception& e)
 	{
 		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return -1;
+		return 1;
 	}
 	return 0;
 }
+
+int Server::handle_channels(int fd, std::istringstream& ss)
+{
+	// It doenst use the stringstream ss, so it must be used to avoid unused parameter warning
+	(void)ss;
+	try
+	{
+		std::string msg = std::string(GREEN) + "You are in the following channels:\n";
+		for (const auto& channel : _channels)
+		{
+			if (channel.second.get_members().count(fd))
+			{
+				msg += std::string(BLUE) + std::string(BOLD) + "#" + channel.first + "\n";
+			}
+		}
+		if (msg == std::string(GREEN) + "You are in the following channels:\n")
+			msg += "None\n";
+		msg += RESET;
+		_clients.at(fd).send(msg);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "Error sending message: " << e.what() << std::endl;
+		return 1;
+	}
+	return 0;
+}
+
+int Server::handle_join(int fd, std::istringstream& ss)
+{
+	std::string channel_name;
+	std::getline(ss >> std::ws, channel_name);
+	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
+	{
+		std::cerr << RED << "Client FD " << fd << " sent an invalid JOIN command: " << channel_name << RESET << std::endl;
+		try
+		{
+			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
+			_clients.at(fd).send(msg);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 1;
+	}
+	channel_name.erase(0, 1);
+	// Check if the channel already exists
+	auto it = _channels.find(channel_name);
+	if (it == _channels.end())
+	{
+		// Channel doesnt exist => create it
+		_channels.emplace(channel_name, Channel(channel_name, _clients));
+		std::cout << GREEN << "Channel " << channel_name << " was created!" << RESET << std::endl;
+	}
+	// Add the client to the channel
+	_channels.at(channel_name).add_client(fd);
+	try
+	{
+		std::string msg = std::string(GREEN) + "You have joined channel: " + channel_name + RESET;
+		_clients.at(fd).send(msg);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "Error sending message: " << e.what() << std::endl;
+		return 1;
+	}
+	std::string message = "Joined the channel";
+	std::cout << GREEN << message << RESET << std::endl;
+	// Notify other clients in the channel (forward a message to all other clients in the channel)
+	_channels.at(channel_name).broadcast_message(message, fd);
+	return 0;
+}
+
+int Server::handle_part(int fd, std::istringstream& ss)
+{
+	std::string channel_name;
+	std::getline(ss >> std::ws, channel_name);
+	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
+	{
+		try
+		{
+			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
+			_clients.at(fd).send(msg);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 1;
+	}
+	channel_name.erase(0, 1);
+	auto it = _channels.find(channel_name);
+	if (it == _channels.end())
+	{
+		try
+		{
+			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
+			_clients.at(fd).send(msg);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 1;
+	}
+	if (!_channels.at(channel_name).remove_client(fd))
+	{
+		try
+		{
+			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
+			_clients.at(fd).send(msg);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return 1;
+	}
+	std::string message = "Has left the channel.";
+	std::cout << GREEN << message << RESET << std::endl;
+	// Notify other clients in the channel (forward a message to all other clients in the channel)
+	_channels.at(channel_name).broadcast_message(message, fd);
+	try
+	{
+		std::string msg = std::string(GREEN) + "You have left the channel: " + channel_name + RESET;
+		_clients.at(fd).send(msg);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "Error sending message: " << e.what() << std::endl;
+		return 1;
+	}
+	return 0;
+}
+
+int Server::handle_privmsg(int fd, std::istringstream& ss)
+{
+	std::string target, message;
+	std::getline(ss >> std::ws, target, ' ');
+	std::getline(ss >> std::ws, message);
+	if (target.empty() || message.empty())
+	{
+		try
+		{
+			std::string msg = std::string(RED) + "ERROR: Invalid PRIVMSG command format. Use PRIVMSG <#channel_name or nickname> <message>" + RESET;
+			_clients.at(fd).send(msg);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+		}
+		return -1;
+	}
+	if (target[0] == '#')
+	{
+		// Target is a channel
+		target.erase(0, 1);
+		auto it = _channels.find(target);
+		if (it == _channels.end())
+		{
+			try
+			{
+				std::string msg = std::string(RED) + "ERROR: Channel does not exist" + RESET;
+				_clients.at(fd).send(msg);
+			}
+			catch (const std::exception& e)
+			{
+				std::cerr << "Error sending message: " << e.what() << std::endl;
+			}
+			return -1;
+		}
+		it->second.broadcast_message(message, fd);
+	}
+	else
+	{
+		// Target is a user
+		bool found = false;
+		for (auto& client : _clients)
+		{
+			if (client.second.get_nickname() == target)
+			{
+				try
+				{
+					std::string msg = "<" + _clients.at(fd).get_nickname() + ": " + message + RESET;
+					client.second.send(msg);
+				}
+				catch (const std::exception& e)
+				{
+					std::cerr << "Error sending message: " << e.what() << std::endl;
+					continue;
+				}
+				found = true;
+				break;
+			}
+		}
+		if (!found)
+		{
+			try
+			{
+				std::string msg = std::string(RED) + "ERROR: User does not exist." + RESET;
+				_clients.at(fd).send(msg);
+			}
+			catch (const std::exception& e)
+			{
+				std::cerr << "Error sending message: " << e.what() << std::endl;
+			}
+		}
+	}
+	return 0;
+}
+
+int Server::handle_quit(int fd, std::istringstream& ss)
+{
+	(void)ss;
+	(void)fd;
+	return -1;
+}
+
+int Server::handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines)
+{
+    std::cout << "Handling command for client FD " << client_fd << std::endl;
+    for (auto &line : lines)
+    {
+        std::string command;
+        std::istringstream ss(line);
+        ss >> command;
+		auto it = handlers.find(command);
+		if (command != "PASS" && !_clients.at(client_fd).get_passed_pass())
+		{
+			try
+			{
+				std::string msg = std::string(YELLOW) + "Your're not authenticated yet. Use PASS <password>, NICK <nickname> or USER <username 0 * :real-name>" + RESET;
+				_clients.at(client_fd).send(msg);
+			}
+			catch (const std::exception& e)
+			{
+				std::cerr << "Error sending message: " << e.what() << std::endl;
+			}
+			continue;
+		}
+		else if (command != "PASS" && command != "NICK" && command != "USER" && !_clients.at(client_fd).is_authenticated())
+		{
+			try
+			{
+				std::string msg = std::string(YELLOW) + "You must authenticate with PASS, NICK, and USER commands before sending other commands." + RESET;
+				_clients.at(client_fd).send(msg);
+			}
+			catch (const std::exception& e)
+			{
+				std::cerr << "Error sending message: " << e.what() << std::endl;
+			}
+			continue;
+		}
+        if (it != handlers.end())
+        {
+			if (it->second(*this, client_fd, ss) == -1)
+			{
+				handle_disconnection(index);
+				return 1;
+			}
+        }
+        else
+        {
+			if (!_clients.at(client_fd).is_authenticated())
+			{
+				try
+				{
+					std::string msg = std::string(RED) + "ERROR: Invalid command. Use PASS, NICK, or USER." + RESET;
+					_clients.at(client_fd).send(msg);
+				}
+				catch (const std::exception& e)
+				{
+					std::cerr << "Error sending message: " << e.what() << std::endl;
+				}
+				continue;
+			}
+			else
+			{
+				try
+				{
+					std::string msg = std::string(RED) + "ERROR: Invalid command. Use JOIN, PART, PRIVMSG, QUIT, NICK, or USER." + RESET;
+					_clients.at(client_fd).send(msg);
+				}
+				catch (const std::exception& e)
+				{
+					std::cerr << "Error sending message: " << e.what() << std::endl;
+				}
+				continue;
+			}
+        }
+    }
+	if (!_clients.at(client_fd).is_authenticated() &&
+    	_clients.at(client_fd).get_passed_pass() &&
+        _clients.at(client_fd).get_passed_nick() &&
+        _clients.at(client_fd).get_passed_user())
+    {
+        _clients.at(client_fd).set_authenticated();
+        std::cout << GREEN << "Client FD " << client_fd << " successfully authenticated." << RESET << std::endl;
+		try
+		{
+			std::string msg = std::string(GREEN) + "Welcome to the server, " + _clients.at(client_fd).get_nickname() + ". You are now authenticated!" + RESET;
+			_clients.at(client_fd).send(msg);
+			std::istringstream params("");
+			handle_help(client_fd, params);
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "Error sending message: " << e.what() << std::endl;
+			return 1;
+		}
+    }
+	return 0;
+}
+
 void Server::process_client_data(size_t& index, int client_fd)
 {
 	char buffer[2];
@@ -449,295 +719,12 @@ void Server::process_client_data(size_t& index, int client_fd)
 	if (lines.empty())
 		return ;
 	// handle authentication. Check if the client sent PASS, NICK, USER commands. If not, send an error message back.
-	if (!_clients.at(client_fd).is_authenticated())
-	{
-		handle_authentication(index, client_fd, lines);
-		return ;
-	}
-	// If the client is authenticated, process the command
+	// if (!_clients.at(client_fd).is_authenticated())
+	// {
+	// 	handle_authentication(index, client_fd, lines);
+	// }
+	// // If the client is authenticated, process the command
 	handle_client_command(index, client_fd, lines);
-}
-
-int Server::handle_client_command(size_t &index, int client_fd, const std::vector<std::string>& lines)
-{
-    std::cout << "Handling command for client FD " << client_fd << std::endl;
-    for (auto &line : lines)
-    {
-        std::string command;
-        std::istringstream ss(line);
-        ss >> command;
-		if (command == "HELP")
-		{
-			if (handle_help(client_fd) == -1)
-				continue ;
-		}
-		else if (command == "CHANNELS")
-		{
-			// Client wants to see which channels he is in.
-			if (handle_channels(client_fd) == -1)
-				continue;
-		}
-		else if (command == "JOIN")
-		{
-			// Client wants to join a channel.
-			std::string channel_name;
-			std::getline(ss >> std::ws, channel_name);
-			if (handle_join(client_fd, channel_name) == -1)
-				continue;
-		}
-		else if (command == "PART")
-		{
-			// Client wants to leave a channel.
-			std::string channel_name;
-			std::getline(ss >> std::ws, channel_name);
-			if (handle_part(client_fd, channel_name) == -1)
-				continue;
-		}
-		else if (command == "PRIVMSG")
-		{
-			// Client wants to send a private message to a channel or a user.
-			std::string target, message;
-			std::getline(ss >> std::ws, target, ' ');
-			std::getline(ss >> std::ws, message);
-			if (handle_privmsg(client_fd, target, message) == -1)
-				continue;
-		}
-		else if (command == "QUIT")
-		{
-			handle_disconnection(index);
-			return 0;
-		}
-		else if (command == "NICK")
-		{
-			std::string nickname;
-			std::getline(ss >> std::ws, nickname);
-			if (parse_nick(nickname, client_fd) == -1)
-				continue;
-		}
-		else if (command == "USER")
-		{
-			std::string user;
-			std::getline(ss >> std::ws, user);
-			if (parse_user(user, client_fd) == -1)
-				continue;
-		}
-		else
-		{
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: Invalid command. Use JOIN, PART, PRIVMSG, QUIT, NICK, or USER." + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-			    std::cerr << "Error sending message: " << e.what() << std::endl;
-				continue;
-			}
-		}
-	}
-	return 1;
-}
-
-int Server::handle_channels(int client_fd)
-{
-	try
-	{
-		std::string msg = std::string(GREEN) + "You are in the following channels:\n";
-		for (const auto& channel : _channels)
-		{
-			if (channel.second.get_clients().count(client_fd))
-			{
-				msg += std::string(BLUE) + std::string(BOLD) + "#" + channel.first + "\n";
-			}
-		}
-		if (msg == std::string(GREEN) + "You are in the following channels:\n")
-			msg += "None\n";
-		msg += RESET;
-		_clients.at(client_fd).send(msg);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return -1;
-	}
-	return 0;
-}
-
-int Server::handle_join(int client_fd, std::string &channel_name)
-{
-	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
-	{
-		std::cerr << RED << "Client FD " << client_fd << " sent an invalid JOIN command: " << channel_name << RESET << std::endl;
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
-			_clients.at(client_fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
-	}
-	channel_name.erase(0, 1);
-	// Check if the channel already exists
-	auto it = _channels.find(channel_name);
-	if (it == _channels.end())
-	{
-		// Channel doesnt exist => create it
-		_channels.emplace(channel_name, Channel(channel_name, _clients));
-		std::cout << GREEN << "Channel " << channel_name << " was created!" << RESET << std::endl;
-	}
-	// Add the client to the channel
-	_channels.at(channel_name).add_client(client_fd);
-	try
-	{
-		std::string msg = std::string(GREEN) + "You have joined channel: " + channel_name + RESET;
-		_clients.at(client_fd).send(msg);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return -1;
-	}
-	std::string message = "Joined the channel";
-	std::cout << GREEN << message << RESET << std::endl;
-	// Notify other clients in the channel (forward a message to all other clients in the channel)
-	_channels.at(channel_name).broadcast_message(message, client_fd);
-	return 0;
-}
-
-int Server::handle_part(int client_fd, std::string &channel_name)
-{
-	if (channel_name.empty() || channel_name.size() < 2 || channel_name[0] != '#')
-	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid channel name. Use #channel_name." + RESET;
-			_clients.at(client_fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
-	}
-	channel_name.erase(0, 1);
-	auto it = _channels.find(channel_name);
-	if (it == _channels.end())
-	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
-			_clients.at(client_fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
-	}
-	if (!_channels.at(channel_name).remove_client(client_fd))
-	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: You are not in this channel." + RESET;
-			_clients.at(client_fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
-	}
-	std::string message = "Has left the channel.";
-	std::cout << GREEN << message << RESET << std::endl;
-	// Notify other clients in the channel (forward a message to all other clients in the channel)
-	_channels.at(channel_name).broadcast_message(message, client_fd);
-	try
-	{
-		std::string msg = std::string(GREEN) + "You have left the channel: " + channel_name + RESET;
-		_clients.at(client_fd).send(msg);
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error sending message: " << e.what() << std::endl;
-		return -1;
-	}
-	return 0;
-}
-
-int Server::handle_privmsg(int client_fd, std::string &target, std::string const &message)
-{
-	if (target.empty() || message.empty())
-	{
-		try
-		{
-			std::string msg = std::string(RED) + "ERROR: Invalid PRIVMSG command format. Use PRIVMSG <#channel_name or nickname> <message>" + RESET;
-			_clients.at(client_fd).send(msg);
-		}
-		catch (const std::exception& e)
-		{
-			std::cerr << "Error sending message: " << e.what() << std::endl;
-		}
-		return -1;
-	}
-	if (target[0] == '#')
-	{
-		// Target is a channel
-		target.erase(0, 1);
-		auto it = _channels.find(target);
-		if (it == _channels.end())
-		{
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: Channel does not exist" + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-			return -1;
-		}
-		it->second.broadcast_message(message, client_fd);
-	}
-	else
-	{
-		// Target is a user
-		bool found = false;
-		for (auto& client : _clients)
-		{
-			if (client.second.get_nickname() == target)
-			{
-				try
-				{
-					std::string msg = "<" + _clients.at(client_fd).get_nickname() + ": " + message + RESET;
-					client.second.send(msg);
-				}
-				catch (const std::exception& e)
-				{
-					std::cerr << "Error sending message: " << e.what() << std::endl;
-					continue;
-				}
-				found = true;
-				break;
-			}
-		}
-		if (!found)
-		{
-			try
-			{
-				std::string msg = std::string(RED) + "ERROR: User does not exist." + RESET;
-				_clients.at(client_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-				std::cerr << "Error sending message: " << e.what() << std::endl;
-			}
-		}
-	}
-	return 0;
 }
 
 // The main server loop for Block 1


### PR DESCRIPTION
1. **Handled Client Commands**: `PART`, `PRIVMSG`, `NICK`, `USER`, `QUIT`, `HELP`, and `CHANNELS` are now processed cleanly and consistently.  
2. **Outsourced client command functions**: The individual client command functions have been separated out, making `handle_client_command()` much cleaner and easier to maintain.  
3. **Improved client feedback**: Clients now receive error messages, private messages, and instructions in a clearer and more structured way.  
4. **Used a map of function pointers (via `std::function`)** to handle client commands, eliminating long `if-else` chains. This makes the code more modular, easier to extend, and optimizes command processing performance.
5. **RFC 2812 compliance from socket to wire**  
   * Every outgoing server message now follows the canonical IRC form  
     `:<servername> <code|command> <params> :<trailing>\r\n`.  
   * Nickname, channel and parameter validation matches the spec, returning the correct numerics

6. **Unified parsing layer**  
   * Introduced a `ParsedMessage` struct (prefix, command, params, trailing).  
   * All handlers, the dispatcher and the auth gate now consume this struct

7. **Robust input handling**  
   * Accepts bare `\n` from raw tools (`telnet`, `nc`) but normalises to `\r\n`.  
   * Enforces the 512-byte IRC hard limit (incl. CRLF) → sends `ERROR` and disconnects on overflow, per RFC *“There is no provision for continuation of message lines.”*

8. **Registration gatekeeper**  
   * `PASS` **must** succeed before any other command.  
   * Only `NICK` and `USER` are accepted until `PASS` is valid.  
   * Once `PASS + NICK + USER` are all set, the client is flagged *authenticated* and receives `001 RPL_WELCOME` followed by a HELP block

9. **Channel mechanics re-worked**  
   * `JOIN` creates channels on demand and broadcasts `:nick JOIN`.  
   * `PART` removes the user, broadcasts `:nick PART`, and checks membership correctly.  
   * New helper `broadcast_to_all()` sends raw wire lines to every client except the sender.