### PR TITLE
Support multi-target JOIN, PART & PRIVMSG

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -16,6 +16,9 @@ class Channel
 {
 	private:
 		std::string _name;
+		std::string _key; // Channel key for private channels, can be empty for public channels
+		std::string _topic; // Channel topic, can be empty
+		bool _is_private; // Whether the channel is private (requires a key to join)
 		std::set<int> _members; // Set of unique client file descriptors, that are part of this channel. With this we can access a client directly through the reference to the clients map in Server
 		std::set<int> _operators; // Set of operators that can perform special actions like kicking clients, inviting clients, change the channel topic, change the channel mode
 		std::unordered_map<int, Client>& _clients_ref; // Reference to the clients map in Server
@@ -28,6 +31,7 @@ class Channel
 		Channel(Channel&& other);
 		~Channel() = default;
 
+		std::string get_name() const;
 		std::set<int> get_members() const;
 		void add_client(int client_fd);
 		size_t remove_client(int client_fd);
@@ -38,6 +42,10 @@ class Channel
 		bool has_member(int client_fd) const;
 
 		void broadcast_message(const std::string& message, int sender_fd) const;
+
+		bool requires_key() const;
+		const std::string& get_channel_key() const;
+		void set_channel_key(const std::string& key);
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -66,6 +66,12 @@ class Server
 		int handle_help(int fd, const ParsedMessage& msg);
 		int handle_channels(int fd, const ParsedMessage& msg);
 		int handle_quit(int fd, const ParsedMessage& msg);
+		int handle_ping(int fd, const ParsedMessage& msg);
+		int handle_mode(int fd, const ParsedMessage& msg);
+		int handle_kick(int fd, const ParsedMessage& msg);
+		int handle_invite(int fd, const ParsedMessage& msg);
+		int handle_topic(int fd, const ParsedMessage& msg);
+		std::vector<std::string> split(const std::string& str, char delimiter);
 		
 	public:
 		// Socket get_listening_socket() const;


### PR DESCRIPTION
- **JOIN**  
  - Accepts comma-separated channel list and optional key list
  - Rejects invalid/missing keys

- **PART**  
  - Accepts comma-separated channel list with a single trailing reason (e.g. `PART #a,#b :Goodbye`)  

- **PRIVMSG**  
  - Accepts comma-separated targets (users and channels) in one command (e.g. `PRIVMSG alice,#a,bob :Hello`)  
  - Broadcasts the same message to each valid recipient 