### PR TITLE
Implement MODE, INVITE, KICK and TOPIC and improved JOIN

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -19,9 +19,14 @@ class Channel
 		std::string _key; // Channel key for private channels, can be empty for public channels
 		std::string _topic; // Channel topic, can be empty
 		bool _is_private; // Whether the channel is private (requires a key to join)
+        bool _invite_only;
+        bool _topic_protected;
+
+        std::set<int> _invited_clients;
 		std::set<int> _members; // Set of unique client file descriptors, that are part of this channel. With this we can access a client directly through the reference to the clients map in Server
 		std::set<int> _operators; // Set of operators that can perform special actions like kicking clients, inviting clients, change the channel topic, change the channel mode
 		std::unordered_map<int, Client>& _clients_ref; // Reference to the clients map in Server
+        int _limit; // Limit of users in the channel, -1 means no limit
 
 	public:
 		Channel(const std::string& name, std::unordered_map<int, Client>& clients);
@@ -40,12 +45,26 @@ class Channel
 		size_t remove_operator(int client_fd);
 
 		bool has_member(int client_fd) const;
+        bool is_operator(int client_fd) const;
 
 		void broadcast_message(const std::string& message, int sender_fd) const;
 
 		bool requires_key() const;
 		const std::string& get_channel_key() const;
-		void set_channel_key(const std::string& key);
+		void set_key(const std::string& key);
+        void remove_key();
+        void set_invite_only(bool invite_only);
+        bool is_invite_only() const;
+        void set_topic_protected(bool topic_protected);
+        bool is_topic_protected() const;
+        void set_topic(const std::string& topic);
+        const std::string& get_topic() const;
+        void set_limit(int limit);
+        void remove_limit();
+        int get_limit() const;
+
+        void add_invited_client(int client_fd);
+        bool is_invited(int client_fd) const;
 };
 
 #endif

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -87,7 +87,7 @@ class Server
 		static void setup_signal_handlers();
 
 		void send_reply(int fd, int code, const std::vector<std::string>& params, const std::string& msg);
-		
+
 		// void handle_new_connection();
 		// void handle_client_data(int client_fd);
 		// void handle_client_disconnect(int client_fd);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -10,76 +10,89 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-# include "Server.hpp"
-# include "Channel.hpp"
+#include "Server.hpp"
+#include "Channel.hpp"
 
-Channel::Channel(const std::string& name, std::unordered_map<int, Client>& clients) : _name(name), _key(""), _topic(""), _is_private(false), _members(), _operators(), _clients_ref(clients)
-{	
+Channel::Channel(const std::string &name, std::unordered_map<int, Client> &clients) : _name(name), _key(""), _topic(""), _is_private(false), _invite_only(false), _invited_clients(), _members(), _operators(), _clients_ref(clients), _limit(-1)
+{
 }
 
-Channel::Channel(Channel&& other) : _name(std::move(other._name)), _key(std::move(other._key)), _topic(std::move(other._topic)), _is_private(other._is_private), _members(std::move(other._members)), _operators(std::move(other._operators)), _clients_ref(other._clients_ref) {}
+Channel::Channel(Channel &&other) : _name(std::move(other._name)), _key(std::move(other._key)), _topic(std::move(other._topic)), _is_private(other._is_private), _invite_only(other._invite_only), _invited_clients(std::move(other._invited_clients)), _members(std::move(other._members)), _operators(std::move(other._operators)), _clients_ref(other._clients_ref), _limit(other._limit) {}
 
 void Channel::add_client(int client_fd)
 {
-	if (_members.find(client_fd) == _members.end())
-	{
-		_members.insert(client_fd);
-		std::cout << "Client FD " << client_fd << " added to channel " << _name << std::endl;
-	}
-	else
-	{
-		std::cerr << "Client FD " << client_fd << " is already in channel " << _name << std::endl;
-	}
+    if (_members.find(client_fd) == _members.end())
+    {
+        _members.insert(client_fd);
+        std::cout << "Client FD " << client_fd << " added to channel " << _name << std::endl;
+    }
+    else
+    {
+        std::cerr << "Client FD " << client_fd << " is already in channel " << _name << std::endl;
+    }
 }
 
 size_t Channel::remove_client(int client_fd)
 {
-	if (_members.find(client_fd) != _members.end())
-	{
-		if (!_members.erase(client_fd))
-			return (0);
-		std::cout << "Client FD " << client_fd << " removed from channel " << _name << std::endl;
-	}
-	else
-	{
-		std::cerr << "Client FD " << client_fd << " not found in channel " << _name << std::endl;
-		return (0);
-	}
-	return (1);
+    if (_members.find(client_fd) != _members.end())
+    {
+        if (!_members.erase(client_fd))
+            return (0);
+        std::cout << "Client FD " << client_fd << " removed from channel " << _name << std::endl;
+    }
+    else
+    {
+        std::cerr << "Client FD " << client_fd << " not found in channel " << _name << std::endl;
+        return (0);
+    }
+    return (1);
 }
 
 void Channel::add_operator(int client_fd)
 {
-	if (_members.find(client_fd) == _members.end())
-	{
-		_members.insert(client_fd);
-		std::cout << "Client FD " << client_fd << " added to the operator list of the channel " << _name << std::endl;
-	}
-	else
-	{
-		std::cerr << "Client FD " << client_fd << " is already an operator of the channel " << _name << std::endl;
-	}
+    if (_operators.find(client_fd) == _operators.end())
+    {
+        _operators.insert(client_fd);
+        std::cout << "Client FD " << client_fd << " added to the operator list of the channel " << _name << std::endl;
+    }
+    else
+    {
+        std::cerr << "Client FD " << client_fd << " is already an operator of the channel " << _name << std::endl;
+    }
 }
 
 size_t Channel::remove_operator(int client_fd)
 {
-	if (_operators.find(client_fd) != _operators.end())
-	{
-		if (!_operators.erase(client_fd))
-			return (0);
-		std::cout << "Client FD " << client_fd << " was removed from the operator list of the channel " << _name << std::endl;
-	}
-	else
-	{
-		std::cerr << "Client FD " << client_fd << " is not an operator of the channel " << _name << std::endl;
-		return (0);
-	}
-	return (1);
+    if (_operators.find(client_fd) != _operators.end())
+    {
+        if (!_operators.erase(client_fd))
+            return (0);
+        std::cout << "Client FD " << client_fd << " was removed from the operator list of the channel " << _name << std::endl;
+    }
+    else
+    {
+        std::cerr << "Client FD " << client_fd << " is not an operator of the channel " << _name << std::endl;
+        return (0);
+    }
+    return (1);
+}
+
+void Channel::add_invited_client(int client_fd)
+{
+    if (_invited_clients.find(client_fd) == _invited_clients.end())
+    {
+        _invited_clients.insert(client_fd);
+        std::cout << "Client FD " << client_fd << " added to the invited list of the channel " << _name << std::endl;
+    }
+    else
+    {
+        std::cerr << "Client FD " << client_fd << " is already invited to the channel " << _name << std::endl;
+    }
 }
 
 std::set<int> Channel::get_members() const
 {
-	return _members;
+    return _members;
 }
 
 // void Server::send_reply(int fd, int code, const std::vector<std::string>& params, const std::string& msg)
@@ -106,49 +119,107 @@ std::set<int> Channel::get_members() const
 //     }
 // }
 
-void Channel::broadcast_message(const std::string& message, int sender_fd) const
+void Channel::broadcast_message(const std::string &message, int sender_fd) const
 {
-	for (const auto& member_fd : _members)
-	{
-		if (member_fd != sender_fd)
-		{
-			try
-			{
-				std::string msg = message;
-				_clients_ref.at(member_fd).send(msg);
-			}
-			catch (const std::exception& e)
-			{
-			    std::cerr << "Failed to broadcast a message to client: " << e.what() << std::endl;
-				return ;
-			}
-		}
-	}
+    for (const auto &member_fd : _members)
+    {
+        if (member_fd != sender_fd)
+        {
+            try
+            {
+                std::string msg = message;
+                _clients_ref.at(member_fd).send(msg);
+            }
+            catch (const std::exception &e)
+            {
+                std::cerr << "Failed to broadcast a message to client: " << e.what() << std::endl;
+                return;
+            }
+        }
+    }
 }
 
 bool Channel::has_member(int client_fd) const
 {
-	return _members.find(client_fd) != _members.end();
+    return _members.find(client_fd) != _members.end();
+}
+
+bool Channel::is_invited(int client_fd) const
+{
+    return _invited_clients.find(client_fd) != _invited_clients.end();
+}
+
+bool Channel::is_operator(int client_fd) const
+{
+    return _operators.find(client_fd) != _operators.end();
 }
 
 bool Channel::requires_key() const
 {
-	return _is_private;
+    return _is_private;
 }
 
-void Channel::set_channel_key(const std::string& key)
+void Channel::set_key(const std::string &key)
 {
-	_key = key;
-	if (!_key.empty())
-		_is_private = true;
-	else
-		_is_private = false;
-	std::cout << "Channel " << _name << " key set to: " << _key << std::endl;
+    _key = key;
+    _is_private = true;
+    std::cout << "Channel " << _name << " is now private with key: " << _key << std::endl;
 }
 
-const std::string& Channel::get_channel_key() const { return _key; }
+void Channel::remove_key()
+{
+    _key.clear();
+    _is_private = false;
+    std::cout << "Channel " << _name << " is now public, key removed." << std::endl;
+}
+
+const std::string &Channel::get_channel_key() const { return _key; }
 
 std::string Channel::get_name() const
 {
-	return _name;
+    return _name;
+}
+
+void Channel::set_invite_only(bool invite_only)
+{
+    _invite_only = invite_only;
+}
+bool Channel::is_invite_only() const
+{
+    return _invite_only;
+}
+
+void Channel::set_topic_protected(bool topic_protected)
+{
+    _topic_protected = topic_protected;
+}
+
+bool Channel::is_topic_protected() const
+{
+    return _topic_protected;
+}
+
+void Channel::set_topic(const std::string &topic)
+{
+    _topic = topic;
+}
+
+const std::string &Channel::get_topic() const
+{
+    return _topic;
+}
+
+void Channel::set_limit(int limit)
+{
+    _limit = limit;
+}
+
+void Channel::remove_limit()
+{
+    _limit = -1;
+}
+
+int Channel::get_limit() const
+{
+    return _limit;
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -134,26 +134,145 @@ void Server::broadcast_to_all(const std::string &message, int sender_fd)
 	}
 }
 
-int Server::handle_mode(int fd, const ParsedMessage &msg)
+// MODE #channel +k 123 // set channel key to 123
+// MODE #channel -k // remove channel key
+// MODE #channel +i // set channel to invite only
+// MODE #channel -i // set channel to public
+// MODE #channel +t   // only operators can change the topic
+// MODE #channel -t // everyone can change the topic
+// MODE #channel +o nick // add operator
+// MODE #channel -o nick // remove operator
+// MODE #channel +l 10 // set limit of 10 users
+// MODE #channel -l // remove limit
+int Server::handle_mode(int fd, const ParsedMessage& msg)
 {
-	(void)msg;
-	(void)fd;
-	// Client &client = _clients.at(fd);
-	// std::string nickname = client.get_nickname();
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
 
-	// if (msg.params.empty())
-	// {
-	// 	send_reply(fd, 461, { nickname, "MODE" }, "Not enough parameters");
-	// 	return 0;
-	// }
-	// std::string param = msg.params[0];
+	// At least 2 params: channel + mode
+	if (msg.params.size() < 2)
+	{
+		send_reply(fd, 461, { nickname, "MODE" }, "Not enough parameters");
+		return 0;
+	}
 
-	// if (param != "o" && )
-	// {
+	std::string chan_name = msg.params[0];
+    std::string mode = msg.params[1];
+	std::string param = (msg.params.size() > 2) ? msg.params[2] : "";
 
-	// }
+	if (chan_name.empty() || chan_name[0] != '#')
+	{
+		send_reply(fd, 476, { nickname, "MODE" }, "Bad channel name");
+		return 0;
+	}
+
+	std::string chan = chan_name.substr(1);
+	auto it = _channels.find(chan);
+	if (it == _channels.end())
+	{
+		send_reply(fd, 403, { nickname, chan_name }, "No such channel");
+		return 0;
+	}
+	Channel &channel = it->second;
+
+	if (!channel.has_member(fd))
+	{
+		send_reply(fd, 442, { nickname, chan_name }, "You're not on that channel");
+		return 0;
+	}
+
+	if (!channel.is_operator(fd))
+	{
+		send_reply(fd, 482, { nickname, chan_name }, "You're not channel operator");
+		return 0;
+	}
+
+	if (mode == "+i")
+		channel.set_invite_only(true);
+	else if (mode == "-i")
+		channel.set_invite_only(false);
+	else if (mode == "+t")
+		channel.set_topic_protected(true);
+	else if (mode == "-t")
+		channel.set_topic_protected(false);
+	else if (mode == "+k")
+	{
+		if (param.empty())
+		{
+			send_reply(fd, 461, { nickname, "MODE" }, "Key parameter required");
+			return 0;
+		}
+		channel.set_key(param);
+	}
+	else if (mode == "-k")
+	{
+		channel.remove_key();
+	}
+	else if (mode == "+o")
+	{
+		if (param.empty())
+		{
+			send_reply(fd, 461, { nickname, "MODE" }, "Nick parameter required");
+			return 0;
+		}
+		int target_fd = find_fd_by_nickname(param);
+		if (target_fd == -1 || !channel.has_member(target_fd))
+		{
+			send_reply(fd, 441, { nickname, param }, "Is not on that channel");
+			return 0;
+		}
+		channel.add_operator(target_fd);
+	}
+	else if (mode == "-o")
+	{
+		if (param.empty())
+		{
+			send_reply(fd, 461, { nickname, "MODE" }, "Nick parameter required");
+			return 0;
+		}
+		int target_fd = find_fd_by_nickname(param);
+		if (target_fd == -1 || !channel.has_member(target_fd))
+		{
+			send_reply(fd, 441, { nickname, param }, "Is not on that channel");
+			return 0;
+		}
+		channel.remove_operator(target_fd);
+	}
+    else if (mode == "+l")
+	{
+        if (param.empty() || !std::all_of(param.begin(), param.end(), ::isdigit))
+        {
+            send_reply(fd, 461, { nickname, "MODE" }, "Numeric parameter required");
+            return 0;
+        }
+        int limit = std::stoi(param);
+        if (limit < 0)
+        {
+            send_reply(fd, 501, { nickname, "MODE" }, "Invalid limit");
+            return 0;
+        }
+        channel.set_limit(limit);
+	}
+	else if (mode == "-l")
+	{
+        channel.remove_limit();
+	}
+	else
+	{
+		send_reply(fd, 472, { nickname, mode }, "Unknown MODE");
+		return 0;
+	}
+
+	// Broadcast MODE change
+	std::string broadcast_msg = ":" + nickname + "!user@host MODE #" + chan_name + " " + mode;
+	if (!param.empty())
+		broadcast_msg += " " + param;
+	broadcast_msg += "\r\n";
+	channel.broadcast_message(broadcast_msg, -1);
+
 	return 0;
 }
+
 
 int Server::find_fd_by_nickname(std::string const &nickname) const
 {

--- a/src/server/command/channel/Invite.cpp
+++ b/src/server/command/channel/Invite.cpp
@@ -3,7 +3,57 @@
 
 int Server::handle_invite(int fd, const ParsedMessage& msg)
 {
-	(void)msg;
-	(void)fd;
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (msg.params.size() < 2)
+	{
+		send_reply(fd, 461, { nickname, "INVITE" }, "Not enough parameters");
+		return 0;
+	}
+
+	std::string target_nick = msg.params[0];
+	std::string chan_name = msg.params[1];
+
+	if (chan_name.empty() || chan_name[0] != '#')
+	{
+		send_reply(fd, 476, { nickname, "INVITE" }, "Bad channel name");
+		return 0;
+	}
+
+	std::string chan = chan_name.substr(1);
+	auto it = _channels.find(chan);
+	if (it == _channels.end())
+	{
+		send_reply(fd, 403, { nickname, chan_name }, "No such channel");
+		return 0;
+	}
+	Channel &channel = it->second;
+
+	if (!channel.is_operator(fd))
+	{
+		send_reply(fd, 482, { nickname, chan_name }, "You're not channel operator");
+		return 0;
+	}
+
+	int target_fd = find_fd_by_nickname(target_nick);
+	if (target_fd == -1)
+	{
+		send_reply(fd, 401, { nickname, target_nick }, "No such nick");
+		return 0;
+	}
+
+	if (channel.has_member(target_fd))
+	{
+		send_reply(fd, 443, { nickname, target_nick, chan_name }, "User already on channel");
+		return 0;
+	}
+
+    channel.add_invited_client(target_fd);
+    
+	// send it to the invited user
+	std::string invite_msg = ":" + nickname + "!user@host INVITE " + target_nick + " :" + chan_name + "\r\n";
+	_clients.at(target_fd).send(invite_msg);
+
 	return 0;
 }

--- a/src/server/command/channel/Join.cpp
+++ b/src/server/command/channel/Join.cpp
@@ -31,6 +31,13 @@ int Server::handle_join(int fd, const ParsedMessage& msg)
 		if (!_channels.count(chan))
 			_channels.emplace(chan, Channel(chan, _clients));
 
+        // if the channel already exists and the client is already a member
+        if (_channels.at(chan).has_member(fd))
+        {
+            send_reply(fd, 443, { nickname, chan }, "You are already on that channel");
+            continue;
+        }
+
 		// If the channel requires a key and the key is not provided or incorrect
 		if (_channels.at(chan).requires_key() && (key.empty() || key != _channels.at(chan).get_channel_key()))
 		{
@@ -38,7 +45,22 @@ int Server::handle_join(int fd, const ParsedMessage& msg)
 			continue;
 		}
 
-		// Add the client to the channel
+        // If the channel has a user limit and the channel is full
+        // AND the user was not invited
+        if (_channels.at(chan).get_limit() != -1 && static_cast<int>(_channels.at(chan).get_members().size()) >= _channels.at(chan).get_limit() && !_channels.at(chan).is_invited(fd))
+		{
+			send_reply(fd, 471, { nickname, chans[i] }, "Cannot join, channel is full");
+			continue;
+		}
+
+        // If the channel is invite-only and the user was not invited
+        if (_channels.at(chan).is_invite_only() && !_channels.at(chan).is_invited(fd))
+        {
+            send_reply(fd, 473, { nickname, chans[i] }, "Cannot join, channel is invite-only");
+            continue;
+        }
+
+		// Finally add the client to the channel
 		_channels.at(chan).add_client(fd);
 		try
 		{
@@ -67,7 +89,7 @@ int Server::handle_join(int fd, const ParsedMessage& msg)
 				return 0;
 			}
 			// Notify other clients in the channel that the client is now an operator
-			std::string message = ':' + _hostname + "MODE #" + _channels.at(chan).get_name() + " +o" + client.get_nickname() + "\r\n";
+			std::string message = ':' + _hostname + "MODE #" + _channels.at(chan).get_name() + " +o " + client.get_nickname() + "\r\n";
 			_channels.at(chan).broadcast_message(message, -1);
 		}
 	}

--- a/src/server/command/channel/Kick.cpp
+++ b/src/server/command/channel/Kick.cpp
@@ -51,7 +51,7 @@ int Server::handle_kick(int fd, const ParsedMessage& msg)
 
 	_clients.at(target_fd).send(kick_msg);
 
-	// delete the channel if it has no members left
+	// delete the channel if it has no members left 
 	if (channel.get_members().empty())
 		_channels.erase(it);
 

--- a/src/server/command/channel/Kick.cpp
+++ b/src/server/command/channel/Kick.cpp
@@ -3,7 +3,57 @@
 
 int Server::handle_kick(int fd, const ParsedMessage& msg)
 {
-	(void)msg;
-	(void)fd;
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (msg.params.size() < 2)
+	{
+		send_reply(fd, 461, { nickname, "KICK" }, "Not enough parameters");
+		return 0;
+	}
+
+	std::string chan_name = msg.params[0];
+	std::string target_nick = msg.params[1];
+	std::string reason = (msg.params.size() > 2) ? msg.params[2] : nickname;
+
+	if (chan_name.empty() || chan_name[0] != '#')
+	{
+		send_reply(fd, 476, { nickname, "KICK" }, "Bad channel name");
+		return 0;
+	}
+
+	std::string chan = chan_name.substr(1);
+	auto it = _channels.find(chan);
+	if (it == _channels.end())
+	{
+		send_reply(fd, 403, { nickname, chan_name }, "No such channel");
+		return 0;
+	}
+	Channel &channel = it->second;
+
+	if (!channel.is_operator(fd))
+	{
+		send_reply(fd, 482, { nickname, chan_name }, "You're not channel operator");
+		return 0;
+	}
+
+	int target_fd = find_fd_by_nickname(target_nick);
+	if (target_fd == -1 || !channel.has_member(target_fd))
+	{
+		send_reply(fd, 441, { nickname, target_nick }, "Is not on that channel");
+		return 0;
+	}
+
+	channel.remove_client(target_fd);
+
+	std::string kick_msg = ":" + nickname + "!user@host KICK " + chan_name + " " + target_nick + " :" + reason + "\r\n";
+	channel.broadcast_message(kick_msg, -1);
+
+	_clients.at(target_fd).send(kick_msg);
+
+	// delete the channel if it has no members left
+	if (channel.get_members().empty())
+		_channels.erase(it);
+
 	return 0;
 }

--- a/src/server/command/channel/Topic.cpp
+++ b/src/server/command/channel/Topic.cpp
@@ -3,7 +3,61 @@
 
 int Server::handle_topic(int fd, const ParsedMessage& msg)
 {
-	(void)msg;
-	(void)fd;
+	Client &client = _clients.at(fd);
+	std::string nickname = client.get_nickname();
+
+	if (msg.params.empty())
+	{
+		send_reply(fd, 461, { nickname, "TOPIC" }, "Not enough parameters");
+		return 0;
+	}
+
+	std::string chan_name = msg.params[0];
+	if (chan_name.empty() || chan_name[0] != '#')
+	{
+		send_reply(fd, 476, { nickname, "TOPIC" }, "Bad channel name");
+		return 0;
+	}
+
+	std::string chan = chan_name.substr(1);
+	auto it = _channels.find(chan);
+	if (it == _channels.end())
+	{
+		send_reply(fd, 403, { nickname, chan_name }, "No such channel");
+		return 0;
+	}
+	Channel &channel = it->second;
+
+	if (!channel.has_member(fd))
+	{
+		send_reply(fd, 442, { nickname, chan_name }, "You're not on that channel");
+		return 0;
+	}
+
+	// just return the topic if no new topic is provided
+	if (msg.params.size() == 1)
+	{
+		std::string topic = channel.get_topic();
+		if (topic.empty())
+			send_reply(fd, 331, { nickname, chan_name }, "No topic is set");
+		else
+			send_reply(fd, 332, { nickname, chan_name }, topic);
+		return 0;
+	}
+
+    // If a new topic is provided, check if the user is allowed to change it
+	if (channel.is_topic_protected() && !channel.is_operator(fd))
+	{
+		send_reply(fd, 482, { nickname, chan_name }, "You're not channel operator");
+		return 0;
+	}
+
+	std::string new_topic = msg.params[1];
+	if (!new_topic.empty() && new_topic[0] == ':')
+		new_topic.erase(0, 1);
+	channel.set_topic(new_topic);
+
+	std::string topic_msg = ":" + nickname + "!user@host TOPIC " + chan_name + " :" + new_topic + "\r\n";
+	channel.broadcast_message(topic_msg, -1);
 	return 0;
 }

--- a/src/server/command/messaging/Privmsg.cpp
+++ b/src/server/command/messaging/Privmsg.cpp
@@ -37,7 +37,7 @@ int Server::handle_privmsg(int fd, const ParsedMessage& msg)
                 continue;
             }
 
-			std::string message1 = ':' + _clients.at(fd).get_nickname() + "@host PRIVMSG #" + _channels.at(chan).get_name() + " :" + text + "\r\n";
+			std::string message1 = ':' + _clients.at(fd).get_nickname() + "!user@host PRIVMSG #" + _channels.at(chan).get_name() + " :" + text + "\r\n";
             ch.broadcast_message(message1, fd);
             continue;
         }
@@ -49,8 +49,8 @@ int Server::handle_privmsg(int fd, const ParsedMessage& msg)
 			continue ;
 		}
 
-		std::string message = ':' + client.get_nickname() + "@host PRIVMSG " + targets[i] + " :" + text + "\r\n";
-		client.send(message);
+		std::string message = ':' + client.get_nickname() + "!user@host PRIVMSG " + targets[i] + " :" + text + "\r\n";
+		_clients.at(fdtg).send(message);
 	}
 	return 0;
 }

--- a/src/server/command/utility/Help.cpp
+++ b/src/server/command/utility/Help.cpp
@@ -15,6 +15,18 @@ int Server::handle_help(int fd, const ParsedMessage &msg)
 	send_reply(fd, 705, {nickname, "*"}, "PART <#chan1,#chan2,...> <optional:leaving_message>      :leave channel");
 	send_reply(fd, 705, {nickname, "*"}, "PRIVMSG <target1,target2,...> <text>                     :send a message");
 	send_reply(fd, 705, {nickname, "*"}, "QUIT                                                     :disconnect");
+
+    send_reply(fd, 705, {nickname, "*"}, "NICK <new_nickname>                                      :change your nickname");
+    send_reply(fd, 705, {nickname, "*"}, "MODE <#channel> <+/-k> <password>                        :set the channel password");
+    send_reply(fd, 705, {nickname, "*"}, "MODE <#channel> <+/-i> <optional:password>               :set channel to invite only or public");
+    send_reply(fd, 705, {nickname, "*"}, "MODE <#channel> <+/-t>                                   :set topic protection");
+    send_reply(fd, 705, {nickname, "*"}, "MODE <#channel> <+/-o> <target_nick>                     :add or remove operator");
+    send_reply(fd, 705, {nickname, "*"}, "MODE <#channel> <+/-l> <optional:limit>                  :set or remove user limit");
+    send_reply(fd, 705, {nickname, "*"}, "KICK <#channel> <target_nick>                            :kick user from channel");
+    send_reply(fd, 705, {nickname, "*"}, "INVITE <target_nick> <#channel>                          :invite user to channel");
+    send_reply(fd, 705, {nickname, "*"}, "TOPIC <#channel> <new_topic>                             :get or set channel topic");
+    send_reply(fd, 705, {nickname, "*"}, "PING <server>                                            :ping the server to check connection");
+    
 	send_reply(fd, 706, {nickname, "*"}, "*** End of HELP ***\n");
 	return 0;
 }


### PR DESCRIPTION
- Implemented `MODE` command with modes:
  - `+k` / `-k`: Set/remove channel key
  - `+i` / `-i`: Enable/disable invite-only mode
  - `+t` / `-t`: Restrict topic changes to operators
  - `+o` / `-o`: Grant/remove operator
  - `+l` / `-l`: Set/remove user limit
- `INVITE`
- `KICK`
- `TOPIC`

Improvements:
- JOIN command behavior adjusted:
  - Invite-only (`+i`) requires an invitation
  - Password-protected (`+k`) requires the correct key
  - User limit (`+l`) blocks joins if full — unless invited
- Fixed a bug in `PRIVMSG`
- Extended `HELP` output with new command descriptions